### PR TITLE
docs: add missing makemigrations step to router setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ In this section, we use healthcare as an example how Starfish-FL can be used.
 
 4. **Create superuser for router** (first time only)
    ```bash
+   docker exec -it starfish-router poetry run python3 manage.py makemigrations
    docker exec -it starfish-router poetry run python3 manage.py migrate
    docker exec -it starfish-router poetry run python3 manage.py createsuperuser
    ```
@@ -131,6 +132,7 @@ See [router/README.md](router/README.md) for detailed installation and configura
 ```bash
 cd router
 docker-compose up -d
+docker exec -it starfish-router poetry run python3 manage.py makemigrations
 docker exec -it starfish-router poetry run python3 manage.py migrate
 docker exec -it starfish-router poetry run python3 manage.py createsuperuser
 ```

--- a/router/README.md
+++ b/router/README.md
@@ -206,11 +206,13 @@ This method gives you more control but requires manual setup of PostgreSQL and P
 
 8. **Run database migrations**
    ```shell
+   python3 manage.py makemigrations
    python3 manage.py migrate
    ```
-   
+
    **Note:** On Windows, you might need to use `python` instead of `python3`:
    ```powershell
+   python manage.py makemigrations
    python manage.py migrate
    ```
 

--- a/workbench/README.md
+++ b/workbench/README.md
@@ -60,9 +60,10 @@ If it is a brand new environment or a clean database, you need to create the dat
    ```bash
    docker-compose exec -it router bash
    ```
-   
+
    Then inside the container:
    ```bash
+   poetry run python3 manage.py makemigrations
    poetry run python3 manage.py migrate
    poetry run python3 manage.py createsuperuser
    ```


### PR DESCRIPTION
Fixes #8

## Summary
- Added `makemigrations` before `migrate` in `README.md` (Quick Start and Router standalone sections)
- Added `makemigrations` before `migrate` in `router/README.md` (local development section)
- Added `makemigrations` before `migrate` in `workbench/README.md` (First Time Setup section)

## Test plan
- [ ] Follow the updated Quick Start in `README.md` and verify `migrate` completes without warnings
- [ ] Follow the updated local dev steps in `router/README.md` and verify `migrate` completes without warnings
- [ ] Follow the updated First Time Setup in `workbench/README.md` and verify `migrate` completes without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)