### PR TITLE
Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # An Agentic Federated Learning Framework
 
+[![Controller Tests](https://github.com/denoslab/starfish-fl/actions/workflows/controller-tests.yml/badge.svg)](https://github.com/denoslab/starfish-fl/actions/workflows/controller-tests.yml)
+[![Router Tests](https://github.com/denoslab/starfish-fl/actions/workflows/router-tests.yml/badge.svg)](https://github.com/denoslab/starfish-fl/actions/workflows/router-tests.yml)
+[![E2E Tests](https://github.com/denoslab/starfish-fl/actions/workflows/e2e-tests.yml/badge.svg)](https://github.com/denoslab/starfish-fl/actions/workflows/e2e-tests.yml)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/)
+[![Django](https://img.shields.io/badge/Django-4.2-green.svg)](https://www.djangoproject.com/)
+[![Docker](https://img.shields.io/badge/Docker-ready-blue.svg)](https://www.docker.com/)
+
 ![Starfish-FL Logo](docs/images/starfish-fl.png)
 
 Starfish-FL is an agentic federated learning (FL) framework that is native to AI agents. It is an essential component of the STARFISH project. It focuses on federated learning and analysis for the Analysis Mandate function of STARFISH.


### PR DESCRIPTION
## Summary

- Add CI status badges for all three GitHub Actions workflows (Controller Tests, Router Tests, E2E Tests)
- Add License (Apache 2.0), Python 3.10, Django 4.2, and Docker badges
- Badges are placed between the title and the logo image

Closes #22

## Test plan

- [x] Verify all CI badges render and link to the correct workflow run pages on GitHub
- [x] Verify License badge links to the `LICENSE` file
- [x] Verify Python, Django, and Docker badges display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)