### PR TITLE
Add R E2E test to CI workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -11,6 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          - name: Python FL
+            file: test_fl_workflow.py
+          - name: R FL
+            file: test_r_fl_workflow.py
+
+    name: "e2e (${{ matrix.test.name }})"
+
     steps:
       - uses: actions/checkout@v4
 
@@ -79,7 +90,7 @@ jobs:
 
       - name: Run E2E tests
         working-directory: e2e
-        run: pytest test_fl_workflow.py -v --timeout=300
+        run: pytest ${{ matrix.test.file }} -v --timeout=300
 
       # ── Collect logs on failure ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Splits the E2E workflow into two separate CI checks using a matrix strategy: **e2e (Python FL)** and **e2e (R FL)**
- Uses `fail-fast: false` so one failing check doesn't cancel the other
- Each check can be managed independently (e.g., required vs optional, re-run individually)

## Test plan

- [ ] CI shows two separate E2E checks: `e2e (Python FL)` and `e2e (R FL)`
- [ ] Each check runs its respective test file independently
- [ ] Failure in one check does not cancel the other

🤖 Generated with [Claude Code](https://claude.com/claude-code)