### PR TITLE
Fix controller CI: add missing 'mice' R package

### DIFF
--- a/.github/workflows/controller-tests.yml
+++ b/.github/workflows/controller-tests.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends r-base-core r-recommended
-          sudo Rscript -e "install.packages(c('jsonlite', 'survival'), repos='https://cloud.r-project.org')"
+          sudo Rscript -e "install.packages(c('jsonlite', 'survival', 'mice'), repos='https://cloud.r-project.org')"
 
       - name: Run tests
         run: poetry run python3 manage.py test


### PR DESCRIPTION
The R Multiple Imputation task requires the 'mice' R package, which was added to the Dockerfile but not to the CI workflow. This caused the controller tests to fail in PR #33.

https://claude.ai/code/session_01WeBCCDFgq9ap2FNDVAy8Uu