### PR TITLE
Add MkDocs site with mkdocstrings and GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,55 @@
+name: Deploy MkDocs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'controller/starfish/controller/tasks/abstract_task.py'
+      - 'controller/starfish/controller/tasks/abstract_r_task.py'
+      - 'controller/starfish/controller/tasks/diagnostics.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs-material mkdocstrings[python]
+          pip install numpy pandas scipy scikit-learn statsmodels lifelines
+          cd controller && pip install -e . || pip install django celery redis django-fsm || true
+
+      - name: Build MkDocs site
+        run: mkdocs build --strict
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/api/abstract-r-task.md
+++ b/docs/api/abstract-r-task.md
@@ -1,0 +1,9 @@
+# AbstractRTask
+
+Base class for R-based federated learning tasks. Provides a Python-R bridge that executes R scripts via subprocess and communicates through JSON files.
+
+::: starfish.controller.tasks.abstract_r_task.AbstractRTask
+    options:
+      show_source: true
+      show_root_heading: true
+      members_order: source

--- a/docs/api/abstract-task.md
+++ b/docs/api/abstract-task.md
@@ -1,0 +1,9 @@
+# AbstractTask
+
+Base class for all Python-based federated learning tasks.
+
+::: starfish.controller.tasks.abstract_task.AbstractTask
+    options:
+      show_source: true
+      show_root_heading: true
+      members_order: source

--- a/docs/api/diagnostics.md
+++ b/docs/api/diagnostics.md
@@ -1,0 +1,9 @@
+# Diagnostics
+
+Shared diagnostic utilities for federated learning tasks. These functions compute privacy-safe summary statistics locally at each site.
+
+::: starfish.controller.tasks.diagnostics
+    options:
+      show_source: true
+      show_root_heading: true
+      members_order: source

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,90 @@
+# Architecture
+
+## System Overview
+
+Starfish-FL uses a hub-and-spoke architecture where a central **Router** coordinates communication between distributed **Controller** sites.
+
+```
+Site A (Controller)  ──┐
+                       ├──  Router (Coordination Server)
+Site B (Controller)  ──┘
+```
+
+- **Sites** run a Controller and can act as a **Coordinator** or **Participant**
+- The **Router** maintains global state and forwards messages -- it never sees raw data
+- Raw data stays local; only model parameters and summary statistics are exchanged
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| **Site** | A participant node with a unique UUID, connects via heartbeat |
+| **Project** | Defines FL tasks (stored as JSON), owned by a coordinator site |
+| **Run** | Execution instance of a project for one batch |
+| **Task** | Individual ML operation within a project (e.g., `CoxProportionalHazards`) |
+
+## Data Model (Router)
+
+- **Site** -- participant node with unique `uid`
+- **Project** -- FL task definitions, owned by a site (coordinator)
+- **ProjectParticipant** -- links a Site to a Project with role (`CO`=coordinator, `PA`=participant)
+- **Run** -- execution instance; uses `django-fsm` for state machine transitions
+
+## Run State Machine
+
+```
+STANDBY --> PREPARING --> RUNNING --> PENDING_SUCCESS --> PENDING_AGGREGATING --> AGGREGATING --> SUCCESS
+    |           |           |              |                    |                   |
+    +-----------+-----------+--------------+--------------------+-------------------+--> FAILED
+```
+
+## FL Task Execution Flow
+
+Each ML task inherits from `AbstractTask` (Python) or `AbstractRTask` (R). The lifecycle methods map to Run states:
+
+1. **`standby()`** -- Validate previous round, notify router
+2. **`preparing()`** -- Load and validate data via `prepare_data()`
+3. **`running()`** -- Execute training via `training()`
+4. **`pending_success()`** -- Upload mid-artifacts and logs to router
+5. **`pending_aggregating()`** -- Coordinator downloads all participant artifacts
+6. **`aggregating()`** -- Coordinator calls `do_aggregate()`, uploads result, loops or finishes
+
+The Controller uses two Celery queues:
+
+- `starfish.run` -- polling and heartbeat
+- `starfish.processor` -- task execution
+
+## Adding a New ML Task
+
+### Python Tasks
+
+1. Create a directory: `controller/starfish/controller/tasks/<task_name>/`
+2. Subclass `AbstractTask` and implement: `validate()`, `prepare_data()`, `training()`, `do_aggregate()`
+3. Add diagnostics via `from starfish.controller.tasks.diagnostics import ...`
+4. Document the task config schema in `controller/TASK_GUIDE.md`
+
+### R Tasks
+
+1. Create a directory: `controller/starfish/controller/tasks/r_<task_name>/` with a `scripts/` subdirectory
+2. Implement `prepare_data.R`, `training.R`, `aggregate.R` in `scripts/`
+3. Source shared diagnostics: `source(file.path(dirname(this_script), "..", "..", "r_diagnostics_utils.R"))`
+4. Create `task.py` extending `AbstractRTask` (sets `r_script_dir`)
+
+!!! note "Dynamic Task Discovery"
+    Tasks are discovered automatically via dynamic import. The model name in CamelCase is converted to snake_case to find the module: `CensoredRegression` -> `censored_regression/task.py`. No explicit registration is required.
+
+## Router API
+
+Base URL: `http://localhost:8000/starfish/api/v1/`
+
+Auth: HTTP Basic Auth
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/sites/` | GET/POST | Site registration |
+| `/sites/heartbeat/` | POST | Site liveness signal |
+| `/projects/` | GET/POST | Project management |
+| `/runs/` | POST | Create runs for a project batch |
+| `/runs/{id}/status/` | PUT | State transitions |
+| `/runs-action/upload/` | POST | Upload artifacts/logs |
+| `/runs-action/download/` | GET | Download artifacts (zipped) |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,52 @@
+# Contributing
+
+Contributions are welcome! Please follow these guidelines.
+
+## Guidelines
+
+1. Code follows existing style and conventions
+2. Tests are included for new features
+3. Documentation is updated as needed
+4. Docker configurations are tested
+
+## Code Formatting
+
+Format Python code using autopep8:
+
+```bash
+autopep8 --exclude='*/migrations/*' --in-place --recursive ./starfish/
+```
+
+## Running Tests
+
+```bash
+# Router
+cd router && python3 manage.py test
+
+# Controller
+cd controller && python3 manage.py test
+
+# Via Docker
+docker exec -it starfish-router poetry run python3 manage.py test
+docker exec -it starfish-controller poetry run python3 manage.py test
+```
+
+## Adding a New Task
+
+See [Architecture](architecture.md#adding-a-new-ml-task) for how to add Python and R tasks.
+
+For every new task:
+
+1. Implement the task class with `prepare_data()`, `training()`, and `do_aggregate()`
+2. Add test coverage in `controller/starfish/controller/test_<task_name>.py`
+3. Add configuration docs to `controller/TASK_GUIDE.md`
+4. Update `controller/USER_GUIDE.md` with result interpretation
+5. Update the supported tasks tables in `README.md` and `docs/index.md`
+
+## License
+
+Apache 2.0
+
+## Support
+
+For issues, questions, or contributions, [open an issue](https://github.com/denoslab/starfish-fl/issues) in the repository.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,128 @@
+# Getting Started
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/engine/install/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
+## Quick Start (All Components)
+
+1. **Clone the repository**
+    ```bash
+    git clone https://github.com/denoslab/starfish-fl.git
+    cd starfish-fl
+    ```
+
+2. **Start all services using Workbench**
+    ```bash
+    cd workbench
+    make build
+    make up
+    ```
+
+3. **Initialize the database** (first time only)
+    ```bash
+    ./init_db.sh
+    ```
+
+4. **Create superuser for router** (first time only)
+    ```bash
+    docker exec -it starfish-router poetry run python3 manage.py makemigrations
+    docker exec -it starfish-router poetry run python3 manage.py migrate
+    docker exec -it starfish-router poetry run python3 manage.py createsuperuser
+    ```
+    Make sure the username and password match what's configured in `workbench/config/controller.env`.
+
+5. **Access the applications**
+    - Router API: [http://localhost:8000/starfish/api/v1/](http://localhost:8000/starfish/api/v1/)
+    - Controller Web Interface: [http://localhost:8001/](http://localhost:8001/)
+
+6. **Stop the services**
+    ```bash
+    make stop    # Stop services
+    make down    # Stop and remove containers
+    ```
+
+## Local Development Without Docker
+
+### Router (requires PostgreSQL)
+
+```bash
+cd router
+poetry install
+python3 manage.py migrate
+python3 manage.py createsuperuser
+python3 manage.py runserver
+```
+
+### Controller (requires Redis)
+
+```bash
+cd controller
+poetry install
+python3 manage.py migrate
+
+# Start Celery workers in separate terminals:
+celery -A starfish beat -l DEBUG
+celery -A starfish worker -l DEBUG -Q starfish.run
+celery -A starfish worker -l DEBUG --concurrency=1 -Q starfish.processor
+
+python3 manage.py runserver
+```
+
+### CLI
+
+```bash
+cd cli
+cp .env.example .env   # fill in SITE_UID, ROUTER_URL, ROUTER_USERNAME, ROUTER_PASSWORD, CONTROLLER_URL
+poetry install
+poetry run starfish --help
+```
+
+## Technology Stack
+
+| Component | Technology |
+|-----------|-----------|
+| Backend | Python 3.10.10, Django 4.2 |
+| Task Queue | Celery + Redis |
+| Databases | PostgreSQL (Router), SQLite (Controller) |
+| Python ML | scikit-learn, NumPy, Pandas, statsmodels, scipy, lifelines |
+| R Runtime | R 4.x with `jsonlite`, `survival`, `mice`, `MASS` |
+| Containers | Docker, Docker Compose |
+| Dependency Management | Poetry |
+
+## Configuration
+
+Each component uses a `.env` file (copy from `.env.example`):
+
+### Controller
+
+| Variable | Description |
+|----------|-------------|
+| `SITE_UID` | Unique UUID for this site |
+| `ROUTER_URL` | URL of the routing server |
+| `ROUTER_USERNAME` | Router authentication username |
+| `ROUTER_PASSWORD` | Router authentication password |
+| `CELERY_BROKER_URL` | Redis connection for Celery |
+| `REDIS_HOST` | Redis host for caching |
+
+### Router
+
+| Variable | Description |
+|----------|-------------|
+| `DATABASE_HOST` | PostgreSQL host |
+| `POSTGRES_DB` | Database name |
+| `POSTGRES_USER` | Database username |
+| `POSTGRES_PASSWORD` | Database password |
+| `SECRET_KEY` | Django secret key |
+| `DEBUG` | Debug mode (False in production) |
+
+## Running Tests
+
+```bash
+# Router
+docker exec -it starfish-router poetry run python3 manage.py test
+
+# Controller
+docker exec -it starfish-controller poetry run python3 manage.py test
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,72 @@
+# Starfish-FL
+
+**An Agentic Federated Learning Framework**
+
+[![Controller Tests](https://github.com/denoslab/starfish-fl/actions/workflows/controller-tests.yml/badge.svg)](https://github.com/denoslab/starfish-fl/actions/workflows/controller-tests.yml)
+[![Router Tests](https://github.com/denoslab/starfish-fl/actions/workflows/router-tests.yml/badge.svg)](https://github.com/denoslab/starfish-fl/actions/workflows/router-tests.yml)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/denoslab/starfish-fl/blob/main/LICENSE)
+[![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/)
+[![R 4.x](https://img.shields.io/badge/R-4.x-276DC3.svg)](https://www.r-project.org/)
+
+Starfish-FL is an agentic federated learning (FL) framework that is native to AI agents. It enables secure, privacy-preserving collaborative machine learning across multiple sites without centralizing sensitive data.
+
+## Built for Biostatisticians
+
+Starfish-FL is designed with biostatisticians and clinical researchers in mind. Every supported analysis method is available in **both Python and R**, so researchers can work in their preferred language without learning a new toolchain.
+
+The task library covers the methods biostatisticians use daily:
+
+| Category | Methods |
+|----------|---------|
+| **Regression** | Linear, Logistic, Ordinal Logistic, Mixed Effects Logistic, SVM, ANCOVA |
+| **Survival Analysis** | Cox Proportional Hazards, Kaplan-Meier |
+| **Censored Outcomes** | Tobit Type I (left/right censoring) |
+| **Count Data** | Poisson, Negative Binomial |
+| **Missing Data** | Multiple Imputation (MICE) with Rubin's rules |
+
+All methods include federated aggregation via inverse-variance weighted meta-analysis and built-in diagnostics (VIF, residuals, goodness-of-fit tests).
+
+## Components
+
+Starfish-FL is a mono-repo with three components:
+
+- **[Controller](https://github.com/denoslab/starfish-fl/tree/main/controller)** -- Installed on each site; handles local ML training, Celery task queuing, and a web UI (port 8001)
+- **[Router](https://github.com/denoslab/starfish-fl/tree/main/router)** -- Central coordination server; manages global state, message forwarding, and artifact storage (port 8000)
+- **[CLI](https://github.com/denoslab/starfish-fl/tree/main/cli)** -- Typer-based CLI (`starfish` command) for human and AI agent use
+
+## Supported Tasks (Python & R)
+
+| Task | Python | R |
+|------|:------:|:-:|
+| Logistic Regression | `LogisticRegression` | `RLogisticRegression` |
+| Statistical Logistic Regression | `LogisticRegressionStats` | -- |
+| Linear Regression | `LinearRegression` | -- |
+| SVM Regression | `SVMRegression` | -- |
+| ANCOVA | `Ancova` | -- |
+| Ordinal Logistic Regression | `OrdinalLogisticRegression` | -- |
+| Mixed Effects Logistic Regression | `MixedEffectsLogisticRegression` | -- |
+| Cox Proportional Hazards | `CoxProportionalHazards` | `RCoxProportionalHazards` |
+| Kaplan-Meier | `KaplanMeier` | `RKaplanMeier` |
+| Censored Regression (Tobit) | `CensoredRegression` | `RCensoredRegression` |
+| Poisson Regression | `PoissonRegression` | `RPoissonRegression` |
+| Negative Binomial Regression | `NegativeBinomialRegression` | `RNegativeBinomialRegression` |
+| Multiple Imputation (MICE) | `MultipleImputation` | `RMultipleImputation` |
+
+## Quick Links
+
+- [Getting Started](getting-started.md) -- Setup and first project
+- [Task Configuration](tasks/configuration.md) -- How to configure FL tasks
+- [User Guide](user-guide.md) -- Web interface walkthrough
+- [API Reference](api/abstract-task.md) -- Python API docs
+- [Architecture](architecture.md) -- System design and data flow
+
+## Citation
+
+```bibtex
+@software{starfish,
+  title = {Starfish-FL: A Federated Learning System},
+  author = {DENOS Lab},
+  year = {2026},
+  url = {https://github.com/denoslab/starfish-fl}
+}
+```

--- a/docs/tasks/configuration.md
+++ b/docs/tasks/configuration.md
@@ -1,0 +1,125 @@
+# Task Configuration
+
+When creating a new project, the **Tasks** field requires a JSON array that defines the federated learning workflow.
+
+For the complete task configuration reference with all model-specific options, see the [full TASK_GUIDE](https://github.com/denoslab/starfish-fl/blob/main/controller/TASK_GUIDE.md).
+
+## Task Structure
+
+Each task must have:
+
+- **seq**: Sequential number (starting from 1)
+- **model**: The ML model class name
+- **config**: Configuration dictionary
+
+```json
+[
+  {
+    "seq": 1,
+    "model": "LogisticRegression",
+    "config": {
+      "total_round": 5,
+      "current_round": 1
+    }
+  }
+]
+```
+
+## Available Models
+
+### Classification & Regression
+
+| Model Name | Description | Dataset Format |
+|-----------|-------------|----------------|
+| `LogisticRegression` | Binary classification | Features + binary label (0/1) |
+| `RLogisticRegression` | R version of logistic regression | Same |
+| `LogisticRegressionStats` | Statistical logistic with inference | Features + binary label, min 30 samples |
+| `LinearRegression` | Continuous value prediction | Features + continuous target |
+| `SVMRegression` | Support Vector Machine regression | Features + continuous target |
+| `Ancova` | Analysis of Covariance | Groups + covariates + outcome |
+| `OrdinalLogisticRegression` | Ordered categorical outcomes | Features + ordinal label (0,1,2,...) |
+| `MixedEffectsLogisticRegression` | Clustered binary data | Group ID + features + binary label |
+
+### Survival Analysis & Censored Outcomes
+
+| Model Name | Description | Dataset Format |
+|-----------|-------------|----------------|
+| `CoxProportionalHazards` | Time-to-event regression | Features + time + event (0/1) |
+| `RCoxProportionalHazards` | R version (survival::coxph) | Same |
+| `KaplanMeier` | Non-parametric survival estimation | Group + features + time + event |
+| `RKaplanMeier` | R version (survival::survfit) | Same |
+| `CensoredRegression` | Tobit Type I (left/right censoring) | Features + outcome + censoring (-1/0/1) |
+| `RCensoredRegression` | R version (survival::survreg) | Same |
+
+### Count Data Models
+
+| Model Name | Description | Dataset Format |
+|-----------|-------------|----------------|
+| `PoissonRegression` | Count data with rate ratios | Features + offset + count |
+| `RPoissonRegression` | R version (glm family=poisson) | Same |
+| `NegativeBinomialRegression` | Overdispersed count data | Features + offset + count |
+| `RNegativeBinomialRegression` | R version (MASS::glm.nb) | Same |
+
+### Missing Data
+
+| Model Name | Description | Dataset Format |
+|-----------|-------------|----------------|
+| `MultipleImputation` | MICE with Rubin's rules | Features (may have NaN) + outcome |
+| `RMultipleImputation` | R version (mice::mice) | Same |
+
+## Required Config Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `total_round` | Total number of federated learning rounds |
+| `current_round` | Starting round (usually 1) |
+
+## Optional Config Parameters
+
+| Parameter | Applies To | Description |
+|-----------|-----------|-------------|
+| `local_epochs` | Classification/Regression | Local training epochs per round |
+| `learning_rate` | Classification/Regression | Training learning rate |
+| `n_group_columns` | ANCOVA | Number of group indicator columns |
+| `vcp_p` | Mixed Effects Logistic | Prior SD for variance components (default: 1.0) |
+| `fe_p` | Mixed Effects Logistic | Prior SD for fixed effects (default: 2.0) |
+| `m` | Multiple Imputation | Number of imputed datasets (default: 5) |
+| `max_iter` | Multiple Imputation | Max MICE iterations (default: 10) |
+
+## Example Configurations
+
+=== "Logistic Regression"
+
+    ```json
+    [{"seq": 1, "model": "LogisticRegression", "config": {"total_round": 5, "current_round": 1}}]
+    ```
+
+=== "Cox PH (R)"
+
+    ```json
+    [{"seq": 1, "model": "RCoxProportionalHazards", "config": {"total_round": 1, "current_round": 1}}]
+    ```
+
+=== "Censored Regression"
+
+    ```json
+    [{"seq": 1, "model": "CensoredRegression", "config": {"total_round": 1, "current_round": 1}}]
+    ```
+
+=== "MICE"
+
+    ```json
+    [{"seq": 1, "model": "MultipleImputation", "config": {"total_round": 1, "current_round": 1, "m": 5, "max_iter": 10}}]
+    ```
+
+## Writing R-Based Tasks
+
+R tasks use a Python-R bridge via `AbstractRTask`. Each R task needs:
+
+1. A Python wrapper class that sets `r_script_dir`
+2. Three R scripts in a `scripts/` subdirectory:
+    - `prepare_data.R` -- validate data
+    - `training.R` -- fit model
+    - `aggregate.R` -- meta-analyze across sites
+
+See [Architecture > Adding a New ML Task](../architecture.md#adding-a-new-ml-task) for details.

--- a/docs/tasks/diagnostics.md
+++ b/docs/tasks/diagnostics.md
@@ -1,0 +1,65 @@
+# Diagnostics Reference
+
+All regression tasks include a `diagnostics` sub-object in their mid-artifact output. These diagnostics are computed locally at each site and provide privacy-safe summary statistics (no individual-level data is shared).
+
+## Common Diagnostics
+
+| Field | Description |
+|-------|-------------|
+| `diagnostics.vif` | Variance Inflation Factor for each feature -- values > 10 suggest multicollinearity |
+| `diagnostics.residual_summary` | Summary statistics of residuals: mean, std, min, q25, median, q75, max |
+| `diagnostics.cooks_distance` | Cook's distance summary: max, mean, n_influential (count > 4/n threshold) |
+
+## OLS / Linear Regression
+
+| Field | Description |
+|-------|-------------|
+| `diagnostics.shapiro_wilk` | Shapiro-Wilk normality test on residuals (statistic, p_value) |
+| `diagnostics.prediction_intervals` | Summary of CI and PI widths (ci_width_mean, pi_width_mean, etc.) |
+
+## Logistic Regression
+
+| Field | Description |
+|-------|-------------|
+| `diagnostics.hosmer_lemeshow` | Hosmer-Lemeshow goodness-of-fit test (statistic, p_value, df) |
+| `diagnostics.deviance_residual_summary` | Summary of deviance residuals |
+| `diagnostics.prediction_intervals` | Summary of predicted probability CI widths |
+
+## Poisson / Negative Binomial
+
+| Field | Description |
+|-------|-------------|
+| `diagnostics.overdispersion` | Overdispersion ratio and p_value -- ratio > 1 suggests overdispersion |
+| `diagnostics.deviance_residual_summary` | Summary of deviance residuals |
+| `diagnostics.pearson_residual_summary` | Summary of Pearson residuals |
+| `diagnostics.prediction_intervals` | Summary of predicted rate CI widths |
+
+## Cox Proportional Hazards
+
+| Field | Description |
+|-------|-------------|
+| `diagnostics.proportional_hazards_test` | Schoenfeld residuals test -- per-feature test_statistic and p_value |
+| `diagnostics.deviance_residual_summary` | Summary of deviance residuals |
+
+## Censored Regression (Tobit)
+
+| Field | Description |
+|-------|-------------|
+| `diagnostics.vif` | Variance Inflation Factor for each feature |
+| `diagnostics.residual_summary` | Residual summary for observed (uncensored) data points |
+| `diagnostics.shapiro_wilk` | Normality test on residuals of observed data |
+| `diagnostics.censoring_summary` | Counts: n_observed, n_right_censored, n_left_censored, pct_censored |
+| `diagnostics.aic` | Akaike Information Criterion |
+| `diagnostics.bic` | Bayesian Information Criterion |
+
+## Multiple Imputation (MICE)
+
+| Field | Description |
+|-------|-------------|
+| `diagnostics.vif` | VIF computed on first imputed dataset |
+| `diagnostics.residual_summary` | Residual summary from first imputed dataset's OLS fit |
+| `diagnostics.shapiro_wilk` | Normality test on first imputed dataset's residuals |
+
+## R Tasks
+
+All R-based tasks include equivalent diagnostics via the shared `r_diagnostics_utils.R` module. The output fields follow the same structure as their Python counterparts.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,85 @@
+# User Guide
+
+This guide covers the Controller web interface for managing federated learning projects.
+
+For the full user guide with dataset formats, result interpretation, and performance metrics, see the [complete Controller User Guide](https://github.com/denoslab/starfish-fl/blob/main/controller/USER_GUIDE.md).
+
+## Register Your Site
+
+When you first access the controller at `http://localhost:8001/controller/`, you'll need to register:
+
+1. Enter a **Site Name** (e.g., "Hospital A")
+2. Enter a **Site Description** (e.g., "Cardiac imaging data site")
+3. Click **Register Site**
+
+## Create a Project (Coordinator)
+
+1. Go to `http://localhost:8001/controller/projects/new/`
+2. Enter project name and description
+3. Configure tasks (see [Task Configuration](tasks/configuration.md))
+4. Submit to create
+5. Wait for participants to join
+6. Upload your local dataset
+7. Start training runs
+
+## Join a Project (Participant)
+
+1. Browse available projects
+2. Review project requirements
+3. Click "Join"
+4. Upload your dataset (matching project schema)
+5. Participate in training rounds
+
+## Dataset Requirements
+
+- **Format**: CSV (comma-separated values)
+- **Header**: No header row -- data starts from the first line
+- **Encoding**: UTF-8
+- **Values**: Numeric only, no missing values (except MICE tasks)
+
+!!! warning "Critical"
+    All sites must have **identical feature sets** (same columns in same order). Use `starfish/preprocess_dataset.py` to ensure consistency.
+
+## Understanding Results
+
+After a successful run, you can download:
+
+| File | Purpose | Who Gets It |
+|------|---------|-------------|
+| **logs.txt** | Training process details | All participants |
+| **artifacts** | Final aggregated results | All participants |
+| **mid-artifacts** | Intermediate local results | Coordinator only |
+
+### Key Metrics by Model Type
+
+| Model Type | Key Metrics |
+|-----------|-------------|
+| Classification | Accuracy, AUC, Sensitivity, Specificity, NPV, PPV |
+| Linear Regression | MSE, MAE, R-squared |
+| Statistical Models | Coefficients, p-values, CI, odds ratios, pseudo R-squared |
+| Survival Models | Hazard ratios, concordance index |
+| Censored Regression | Coefficients, sigma, log-likelihood, censoring summary |
+| Count Data | Rate ratios, deviance, dispersion parameter |
+
+### Model Diagnostics
+
+All regression tasks include diagnostics in their output:
+
+| Diagnostic | What It Tells You | Concerning Values |
+|-----------|-------------------|-------------------|
+| **VIF** | Multicollinearity between features | VIF > 10 |
+| **Shapiro-Wilk** | Are residuals normally distributed? | p < 0.05 |
+| **Hosmer-Lemeshow** | Is the logistic model well-calibrated? | p < 0.05 |
+| **Overdispersion** | More variance than expected? | ratio >> 1 |
+| **Cook's distance** | How many outliers affect the model? | Many influential points |
+| **PH test** (Cox) | Proportional hazards assumption met? | p < 0.05 |
+| **Censoring summary** | Breakdown of censored observations | High % censored may reduce power |
+
+## Project Roles
+
+| Role | Capabilities |
+|------|-------------|
+| **Coordinator** | Create project, approve participants, start runs, aggregate models, also trains locally |
+| **Participant** | Join projects, upload data, train locally, view results |
+
+The coordinator is also a participant -- they train on their own data **and** aggregate all participants' models.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,67 @@
+site_name: Starfish-FL
+site_description: An Agentic Federated Learning Framework
+site_url: https://denoslab.github.io/starfish-fl/
+repo_url: https://github.com/denoslab/starfish-fl
+repo_name: denoslab/starfish-fl
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: blue
+      accent: light blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: blue
+      accent: light blue
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.highlight
+    - content.code.copy
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [controller]
+          options:
+            show_source: false
+            show_root_heading: true
+            heading_level: 3
+            docstring_style: numpy
+            members_order: source
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+  - attr_list
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - User Guide: user-guide.md
+  - Tasks:
+      - Task Configuration: tasks/configuration.md
+      - Diagnostics Reference: tasks/diagnostics.md
+  - API Reference:
+      - AbstractTask: api/abstract-task.md
+      - AbstractRTask: api/abstract-r-task.md
+      - Diagnostics: api/diagnostics.md
+  - Architecture: architecture.md
+  - Contributing: contributing.md


### PR DESCRIPTION
## Summary
- Set up MkDocs with Material theme and `mkdocstrings[python]` for auto-generating HTML docs from Python docstrings
- Added documentation pages: getting started, architecture, user guide, task configuration, diagnostics reference
- Added API reference pages for `AbstractTask`, `AbstractRTask`, and `diagnostics` module using mkdocstrings directives
- Added GitHub Actions workflow (`.github/workflows/docs.yml`) to build and deploy to GitHub Pages on pushes to `main`

Closes #42

## Test plan
- [ ] Run `mkdocs build --strict` locally to verify site builds without errors
- [ ] Run `mkdocs serve` to preview site locally at `http://localhost:8000`
- [ ] Verify API reference pages render docstrings from source modules
- [ ] Verify GitHub Actions workflow triggers on push to main
- [ ] Enable GitHub Pages (Settings > Pages > Source: GitHub Actions) in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)