### PR TITLE
Add autonomous FL experiment agent (end-to-end) (#54)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Starfish-FL is an agentic federated learning (FL) framework organized as a mono 
 
 - **`controller/`** — Django app installed on every site; handles local ML training, Celery task queuing, and a web UI (port 8001); includes optional LLM agent hooks (`controller/starfish/controller/agent/`) for per-round summaries, convergence detection, outlier flagging, and failure triage
 - **`router/`** — Django REST Framework app acting as central coordination server; manages global state, message forwarding, and artifact storage (port 8000); includes an embedded LLM agent module (`router/starfish/agent/`) for adaptive aggregation, smart scheduling, and failure triage
-- **`cli/`** — Typer-based CLI (`starfish` command) that replicates web portal functionality for human and AI agent use; includes an LLM agent module (`cli/starfish_cli/agent/`) for autonomous FL orchestration via Claude tool use
+- **`cli/`** — Typer-based CLI (`starfish` command) that replicates web portal functionality for human and AI agent use; includes an LLM agent module (`cli/starfish_cli/agent/`) for autonomous FL orchestration via Claude tool use, with an autonomous experiment mode that can analyze datasets, auto-select models, run experiments end-to-end, interpret results, and iteratively refine
 - **`workbench/`** — Docker Compose orchestration for running all components together in development
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Starfish-FL is a complete federated learning platform consisting of three main c
 
 - **[Controller](controller/)** - Site management and FL task execution
 - **[Router](router/)** - Central coordination and message routing
-- **[CLI](cli/)** - Typer-based CLI (`starfish` command) for human and AI agent use, with built-in LLM agent for autonomous orchestration
+- **[CLI](cli/)** - Typer-based CLI (`starfish` command) for human and AI agent use, with built-in LLM agent for autonomous orchestration and end-to-end experiment automation
 - **[Workbench](workbench/)** - Development and testing environment
 
 ### Architecture
@@ -189,6 +189,7 @@ make down        # Stop and remove containers
 - **[Controller User Guide](controller/USER_GUIDE.md)** - Comprehensive guide for using the Controller web interface
 - **[Task Configuration Guide](controller/TASK_GUIDE.md)** - How to configure FL tasks and models
 - **[CLI Agent Guide](cli/README.md#ai-agent)** - Using the AI agent for autonomous FL orchestration
+- **[Autonomous Experiment Guide](cli/README.md#autonomous-experiment-mode)** - End-to-end experiment automation: dataset analysis, model selection, execution, and result interpretation
 
 ## Development
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -40,7 +40,7 @@ starfish project   list / new / join / leave / detail
 starfish run       start / status / detail / logs
 starfish dataset   upload
 starfish artifact  download
-starfish agent     run / tools
+starfish agent     run / experiment / tools
 ```
 
 ## AI Agent
@@ -77,9 +77,43 @@ poetry run starfish agent run "Monitor my runs" --model claude-haiku-4-5-2025100
 |--------|-------------|
 | `--model` / `-m` | Anthropic model to use (default: `claude-sonnet-4-6`) |
 | `--api-key` / `-k` | Anthropic API key (default: `ANTHROPIC_API_KEY` env var) |
-| `--max-turns` | Maximum agent turns (default: 50) |
+| `--max-turns` | Maximum agent turns (default: 50 for `run`, 100 for `experiment`) |
 | `--verbose` / `-v` | Show tool calls and results |
 | `--json` | Output full conversation as JSON |
+
+### Autonomous Experiment Mode
+
+The `experiment` command provides a fully autonomous FL experiment workflow. Given dataset paths and a research goal, the agent will analyze the data, select the appropriate model, configure the project, run the experiment end-to-end, and interpret results — iterating to find the best approach.
+
+```bash
+# Run an autonomous experiment
+poetry run starfish agent experiment \
+  "Analyze the dataset at /data/site1.csv and /data/site2.csv, \
+   choose the best model, run a federated learning experiment, \
+   and interpret the results" --verbose
+
+# Survival analysis experiment
+poetry run starfish agent experiment \
+  "Run a survival analysis on /data/veteran_site1.csv and /data/veteran_site2.csv \
+   using two sites. The data has time and event columns." --verbose
+```
+
+#### Experiment Tools
+
+In addition to all CLI tools, the experiment agent has access to local analysis tools:
+
+| Tool | Description |
+|------|-------------|
+| `analyze_dataset` | Analyze CSV structure, column types, and detected patterns |
+| `recommend_task` | Recommend FL task types based on data analysis |
+| `generate_config` | Generate task config JSON for a model with correct defaults |
+| `interpret_results` | Parse and interpret experiment artifact files |
+| `compare_experiments` | Compare results across multiple experiments and rank models |
+
+List all tools (including experiment tools) with:
+```bash
+poetry run starfish agent tools --all
+```
 
 ## Example workflow would look something like
 ```bash

--- a/cli/starfish_cli/agent/agent.py
+++ b/cli/starfish_cli/agent/agent.py
@@ -26,6 +26,8 @@ def run_agent_loop(
     api_key: str | None = None,
     max_turns: int = MAX_TURNS,
     verbose: bool = False,
+    system_prompt: str | None = None,
+    tools: list[dict] | None = None,
 ) -> list[dict]:
     """
     Run the agent loop to accomplish a user-specified goal.
@@ -44,6 +46,10 @@ def run_agent_loop(
         Maximum number of LLM turns before stopping.
     verbose : bool
         If True, print each tool call and result.
+    system_prompt : str | None
+        Custom system prompt. If None, uses the default SYSTEM_PROMPT.
+    tools : list[dict] | None
+        Custom tool schemas. If None, uses get_tool_schemas() (CLI tools only).
 
     Returns
     -------
@@ -53,15 +59,16 @@ def run_agent_loop(
     if client is None:
         client = create_client(api_key)
 
-    tools = get_tool_schemas()
+    effective_prompt = system_prompt if system_prompt is not None else SYSTEM_PROMPT
+    effective_tools = tools if tools is not None else get_tool_schemas()
     messages = [{"role": "user", "content": goal}]
 
     for turn in range(max_turns):
         response = client.messages.create(
             model=model,
             max_tokens=4096,
-            system=SYSTEM_PROMPT,
-            tools=tools,
+            system=effective_prompt,
+            tools=effective_tools,
             messages=messages,
         )
 

--- a/cli/starfish_cli/agent/prompts.py
+++ b/cli/starfish_cli/agent/prompts.py
@@ -1,5 +1,8 @@
 """
-System prompt for the Starfish-FL agent with FL domain knowledge.
+System prompts for the Starfish-FL agent with FL domain knowledge.
+
+SYSTEM_PROMPT is used for the basic agent (starfish agent run).
+EXPERIMENT_SYSTEM_PROMPT extends it for autonomous experiments (starfish agent experiment).
 """
 
 SYSTEM_PROMPT = """You are an AI agent that orchestrates federated learning (FL) experiments \
@@ -74,4 +77,93 @@ Optional config fields vary by task (e.g., `target_column`, `feature_columns`, `
 - On failure, always fetch logs to understand the root cause before suggesting fixes
 - Never retry a failed operation without understanding why it failed
 - When downloading artifacts, the output is a ZIP file saved to the specified directory
+"""
+
+EXPERIMENT_SYSTEM_PROMPT = SYSTEM_PROMPT + """
+
+## Autonomous Experiment Mode
+
+You are running in autonomous experiment mode. Your goal is to analyze datasets, \
+select appropriate models, run FL experiments end-to-end, and interpret results. \
+You have additional local tools for dataset analysis and result interpretation.
+
+### Experiment Planning Strategy
+
+Follow this sequence for every experiment:
+1. **Analyze**: Use `analyze_dataset` on each CSV file to understand the data structure.
+2. **Recommend**: Use `recommend_task` with the analysis to get ranked model suggestions.
+3. **Configure**: Use `generate_config` to create the task JSON for your chosen model.
+4. **Setup**: Register sites, create the project (with the generated config), and join participants.
+5. **Run**: Start the run batch, upload datasets for each site.
+6. **Monitor**: Poll `starfish_run_status` periodically until all runs reach SUCCESS or FAILED.
+7. **Interpret**: Download artifacts and use `interpret_results` to parse them.
+8. **Iterate**: If results are poor, try a different model and use `compare_experiments`.
+
+### Dataset Analysis Heuristics
+
+When analyzing a dataset, look for these patterns:
+- **Binary last column (0/1)**: Classification problem -> LogisticRegression
+- **Binary last + positive continuous second-to-last**: Survival -> CoxProportionalHazards
+- **Non-negative integer last column**: Count data -> PoissonRegression
+- **Censoring indicator {-1, 0, 1} in last column**: Censored -> CensoredRegression
+- **Missing values present**: Consider MultipleImputation first
+- **Ordinal integer last column (3+ levels)**: OrdinalLogisticRegression
+- **Group/cluster column + binary outcome**: MixedEffectsLogisticRegression
+- **Continuous last column**: Regression -> LinearRegression
+- **Group column + continuous outcome**: Ancova
+
+### Task Selection Decision Tree
+
+Is the outcome variable...
+- Binary (0/1)?
+  - Is there a time variable? -> CoxProportionalHazards or KaplanMeier
+  - Are observations clustered? -> MixedEffectsLogisticRegression
+  - Need statistical inference? -> LogisticRegressionStats
+  - Otherwise -> LogisticRegression
+- Ordinal (3+ ordered levels)? -> OrdinalLogisticRegression
+- Count (non-negative integer)?
+  - Overdispersed? -> NegativeBinomialRegression
+  - Otherwise -> PoissonRegression
+- Censored continuous? -> CensoredRegression
+- Continuous?
+  - Group comparison needed? -> Ancova
+  - Otherwise -> LinearRegression
+- Missing data present? -> MultipleImputation (then apply one of the above)
+
+### Choosing Number of Rounds
+
+- **Single-round models** (total_round=1): CoxProportionalHazards, KaplanMeier, \
+PoissonRegression, NegativeBinomialRegression, CensoredRegression, MultipleImputation, \
+Ancova, LogisticRegressionStats, OrdinalLogisticRegression, MixedEffectsLogisticRegression
+- **Iterative models**: LogisticRegression (3-10 rounds), LinearRegression (3-10 rounds), \
+SvmRegression (3-10 rounds), FederatedUNet (5-20 rounds)
+
+### Result Interpretation Guidelines
+
+- **Accuracy/AUC > 0.8**: Good performance for classification
+- **R-squared > 0.6**: Reasonable fit for regression
+- **Concordance > 0.7**: Good discrimination for survival models
+- **VIF > 10**: Multicollinearity concern -- consider removing correlated features
+- **Shapiro-Wilk p < 0.05**: Residuals may not be normally distributed
+- **Cook's D n_influential > 5% of n**: Check for influential outliers
+- **Overdispersion ratio > 1.5**: Consider Negative Binomial instead of Poisson
+
+### Iterative Refinement
+
+When results are poor or inconclusive:
+1. Try a different model from the recommendations
+2. Adjust the number of rounds (more rounds for iterative models)
+3. If LogisticRegression accuracy is low, try LogisticRegressionStats for deeper analysis
+4. If Poisson shows overdispersion, switch to NegativeBinomialRegression
+5. If data has missing values, run MultipleImputation first
+6. Use `compare_experiments` to compare across multiple attempts and identify the best model
+
+### Report Format
+
+When generating a final report, include:
+1. **Dataset Summary**: Number of samples, features, outcome type
+2. **Model Selection Rationale**: Why this model was chosen
+3. **Results**: Key metrics and coefficients
+4. **Diagnostics**: Any concerns (multicollinearity, non-normality, influential points)
+5. **Recommendations**: Next steps or alternative approaches to try
 """

--- a/cli/starfish_cli/agent/runner.py
+++ b/cli/starfish_cli/agent/runner.py
@@ -96,13 +96,104 @@ def run(
 
 
 @app.command()
+def experiment(
+    goal: str = typer.Argument(..., help="Describe the experiment (include dataset paths and research goal)"),
+    model: str = typer.Option(
+        "claude-sonnet-4-6",
+        "--model", "-m",
+        help="Anthropic model to use"
+    ),
+    api_key: Optional[str] = typer.Option(
+        None,
+        "--api-key", "-k",
+        help="Anthropic API key (default: ANTHROPIC_API_KEY env var)",
+        envvar="ANTHROPIC_API_KEY",
+    ),
+    max_turns: int = typer.Option(
+        100,
+        "--max-turns",
+        help="Maximum number of agent turns (default: 100)"
+    ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose", "-v",
+        help="Show tool calls and results"
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Output full conversation as JSON"
+    ),
+):
+    """Run an autonomous FL experiment: analyze data, select model, train, and interpret results."""
+    try:
+        from anthropic import Anthropic
+    except ImportError:
+        typer.echo(
+            "Error: anthropic package not installed. "
+            "Install it with: poetry install --extras agent"
+        )
+        raise typer.Exit(code=1)
+
+    from starfish_cli.agent.agent import run_agent_loop, extract_final_response
+    from starfish_cli.agent.prompts import EXPERIMENT_SYSTEM_PROMPT
+    from starfish_cli.agent.tools import get_experiment_tool_schemas
+
+    if not api_key:
+        typer.echo("Error: ANTHROPIC_API_KEY not set. Provide via --api-key or environment variable.")
+        raise typer.Exit(code=1)
+
+    if verbose:
+        typer.echo(f"Experiment goal: {goal}")
+        typer.echo(f"Model: {model}")
+        typer.echo("Mode: autonomous experiment")
+        typer.echo("---")
+
+    messages = run_agent_loop(
+        goal=goal,
+        model=model,
+        api_key=api_key,
+        max_turns=max_turns,
+        verbose=verbose,
+        system_prompt=EXPERIMENT_SYSTEM_PROMPT,
+        tools=get_experiment_tool_schemas(),
+    )
+
+    if json_output:
+        serializable = []
+        for msg in messages:
+            if msg["role"] == "assistant":
+                content = []
+                for block in msg["content"]:
+                    if hasattr(block, "text"):
+                        content.append({"type": "text", "text": block.text})
+                    elif hasattr(block, "name"):
+                        content.append({
+                            "type": "tool_use",
+                            "name": block.name,
+                            "input": block.input,
+                        })
+                serializable.append({"role": "assistant", "content": content})
+            else:
+                serializable.append(msg)
+        typer.echo(json.dumps(serializable, indent=2))
+    else:
+        final = extract_final_response(messages)
+        if final:
+            typer.echo(final)
+        else:
+            typer.echo("Experiment completed without a final text response.")
+
+
+@app.command()
 def tools(
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+    all_tools: bool = typer.Option(False, "--all", help="Include experiment-specific tools"),
 ):
     """List all available agent tools and their schemas."""
-    from starfish_cli.agent.tools import get_tool_schemas
+    from starfish_cli.agent.tools import get_tool_schemas, get_experiment_tool_schemas
 
-    schemas = get_tool_schemas()
+    schemas = get_experiment_tool_schemas() if all_tools else get_tool_schemas()
 
     if json_output:
         typer.echo(json.dumps(schemas, indent=2))
@@ -112,7 +203,8 @@ def tools(
     from rich.table import Table
 
     console = Console()
-    table = Table(title="Starfish Agent Tools")
+    title = "Starfish Agent Tools (all)" if all_tools else "Starfish Agent Tools"
+    table = Table(title=title)
     table.add_column("Tool Name", style="cyan")
     table.add_column("Description")
     table.add_column("Required Params", style="green")

--- a/cli/starfish_cli/agent/tools.py
+++ b/cli/starfish_cli/agent/tools.py
@@ -2,11 +2,17 @@
 Tool definitions that map starfish CLI commands to LLM agent tools.
 
 Each tool has a schema (for the LLM) and an execute function (runs the CLI).
+Experiment-specific local tools (analyze_dataset, recommend_task, etc.) perform
+direct Python operations without invoking the CLI.
 """
 
+import csv
 import json
 import os
+import statistics
 import subprocess
+from collections import Counter
+from pathlib import Path
 
 
 def _build_cmd(args: list[str], env_file: str | None = None) -> list[str]:
@@ -507,13 +513,676 @@ TOOL_HANDLERS = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Experiment-specific local tools (no CLI subprocess)
+# ---------------------------------------------------------------------------
+
+LOCAL_TOOL_DEFINITIONS = [
+    {
+        "name": "analyze_dataset",
+        "description": (
+            "Analyze a local CSV file to understand its structure, column types, "
+            "and statistical properties. Returns column metadata, basic statistics, "
+            "and detected patterns (binary outcome, time-to-event, count data, etc.) "
+            "to help choose the right FL task."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": "Path to the CSV file to analyze"
+                },
+                "has_header": {
+                    "type": "boolean",
+                    "description": "Whether the CSV has a header row (default: false, matching Starfish convention)"
+                }
+            },
+            "required": ["file_path"]
+        }
+    },
+    {
+        "name": "recommend_task",
+        "description": (
+            "Recommend suitable Starfish FL task types based on dataset analysis. "
+            "Takes the output from analyze_dataset and returns ranked task "
+            "recommendations with rationale."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "analysis": {
+                    "type": "object",
+                    "description": "Dataset analysis result from analyze_dataset tool"
+                },
+                "preference": {
+                    "type": "string",
+                    "enum": ["python", "r", "any"],
+                    "description": "Language preference for task implementation (default: 'any')"
+                }
+            },
+            "required": ["analysis"]
+        }
+    },
+    {
+        "name": "generate_config",
+        "description": (
+            "Generate a Starfish task configuration JSON array for a given model "
+            "type. Returns the complete tasks JSON string ready for project creation."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "model": {
+                    "type": "string",
+                    "description": "Model class name (e.g., 'LogisticRegression', 'CoxProportionalHazards')"
+                },
+                "total_round": {
+                    "type": "integer",
+                    "description": "Number of federated rounds (default depends on model type)"
+                },
+                "config_overrides": {
+                    "type": "object",
+                    "description": "Additional config parameters (e.g., {'m': 10} for MultipleImputation)"
+                }
+            },
+            "required": ["model"]
+        }
+    },
+    {
+        "name": "interpret_results",
+        "description": (
+            "Parse Starfish artifact files from a directory and produce a "
+            "structured interpretation of the FL experiment results. Reads JSON "
+            "artifact files and extracts model coefficients, metrics, and diagnostics."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "artifact_dir": {
+                    "type": "string",
+                    "description": "Directory containing downloaded artifact files"
+                },
+                "model": {
+                    "type": "string",
+                    "description": "Model type to help interpret results (e.g., 'LogisticRegression')"
+                }
+            },
+            "required": ["artifact_dir"]
+        }
+    },
+    {
+        "name": "compare_experiments",
+        "description": (
+            "Compare results from multiple FL experiments to identify the best "
+            "model. Takes a list of experiment result summaries and returns a "
+            "comparative analysis with rankings."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "experiments": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": "List of experiment result objects (from interpret_results)"
+                }
+            },
+            "required": ["experiments"]
+        }
+    },
+]
+
+
+def _infer_column_type(values: list[str]) -> dict:
+    """Infer the type and compute stats for a column of string values."""
+    non_empty = [v for v in values if v.strip() != ""]
+    n_missing = len(values) - len(non_empty)
+
+    if not non_empty:
+        return {"dtype": "empty", "n_unique": 0, "n_missing": n_missing, "stats": {}}
+
+    # Try to parse as numeric
+    numeric_vals = []
+    for v in non_empty:
+        try:
+            numeric_vals.append(float(v))
+        except (ValueError, TypeError):
+            break
+
+    if len(numeric_vals) == len(non_empty):
+        # All values are numeric
+        unique = set(numeric_vals)
+        n_unique = len(unique)
+        is_integer = all(v == int(v) for v in numeric_vals)
+
+        if is_integer and unique == {0, 1}:
+            dtype = "binary"
+        elif is_integer and n_unique <= 20:
+            dtype = "numeric_integer"
+        else:
+            dtype = "numeric_continuous"
+
+        stats = {
+            "min": min(numeric_vals),
+            "max": max(numeric_vals),
+            "mean": round(statistics.mean(numeric_vals), 4),
+        }
+        if len(numeric_vals) >= 2:
+            stats["std"] = round(statistics.stdev(numeric_vals), 4)
+
+        return {
+            "dtype": dtype,
+            "n_unique": n_unique,
+            "n_missing": n_missing,
+            "stats": stats,
+        }
+
+    # Non-numeric: categorical
+    counter = Counter(non_empty)
+    top_3 = counter.most_common(3)
+    return {
+        "dtype": "categorical",
+        "n_unique": len(counter),
+        "n_missing": n_missing,
+        "stats": {"top_values": [{"value": v, "count": c} for v, c in top_3]},
+    }
+
+
+def _detect_patterns(columns: list[dict]) -> dict:
+    """Detect data patterns from column analysis to guide task selection."""
+    if not columns:
+        return {}
+
+    patterns = {}
+    last = columns[-1]
+    second_last = columns[-2] if len(columns) >= 2 else None
+
+    # Binary outcome: last column is binary (0/1)
+    if last["dtype"] == "binary":
+        patterns["binary_outcome"] = True
+
+        # Time-to-event: second-to-last is positive continuous, last is binary
+        if second_last and second_last["dtype"] == "numeric_continuous":
+            if second_last["stats"].get("min", -1) >= 0:
+                patterns["time_to_event"] = True
+
+        # Group/cluster column: first column has few unique values
+        first = columns[0]
+        if first["dtype"] in ("numeric_integer", "categorical") and first["n_unique"] <= 20:
+            patterns["group_column"] = True
+
+    # Count data: last column is non-negative integer
+    elif last["dtype"] == "numeric_integer":
+        if last["stats"].get("min", -1) >= 0:
+            patterns["count_data"] = True
+        # Ordinal outcome: 3+ ordered integer levels
+        if last["n_unique"] >= 3:
+            patterns["ordinal_outcome"] = True
+
+    # Continuous outcome
+    elif last["dtype"] == "numeric_continuous":
+        patterns["continuous_outcome"] = True
+
+        # Censoring indicator: second-to-last is continuous, last has {-1, 0, 1}
+        if second_last and second_last["dtype"] == "numeric_continuous":
+            pass  # Just continuous regression
+
+        # Group column for ANCOVA
+        first = columns[0]
+        if first["dtype"] in ("numeric_integer", "categorical") and first["n_unique"] <= 20:
+            patterns["group_column"] = True
+
+    # Censoring: last column contains only {-1, 0, 1}
+    if last["dtype"] == "numeric_integer" and last["n_unique"] <= 3:
+        vals = set()
+        if last["stats"].get("min") is not None:
+            vals.add(int(last["stats"]["min"]))
+        if last["stats"].get("max") is not None:
+            vals.add(int(last["stats"]["max"]))
+        if vals <= {-1, 0, 1} and len(vals) >= 2:
+            # Check if second-to-last is continuous (outcome variable)
+            if second_last and second_last["dtype"] == "numeric_continuous":
+                patterns["censored"] = True
+
+    # Missing data: any column has missing values
+    if any(c["n_missing"] > 0 for c in columns):
+        patterns["missing_data"] = True
+
+    return patterns
+
+
+def _execute_analyze_dataset(params: dict) -> dict:
+    """Analyze a CSV file and return column metadata and detected patterns."""
+    file_path = params.get("file_path", "")
+    has_header = params.get("has_header", False)
+
+    if not file_path or not os.path.exists(file_path):
+        return {"success": False, "msg": f"File not found: {file_path}"}
+
+    try:
+        with open(file_path, "r", newline="") as f:
+            reader = csv.reader(f)
+            rows = list(reader)
+    except Exception as e:
+        return {"success": False, "msg": f"Error reading CSV: {str(e)}"}
+
+    if not rows:
+        return {"success": False, "msg": "CSV file is empty"}
+
+    if has_header:
+        headers = rows[0]
+        data_rows = rows[1:]
+    else:
+        data_rows = rows
+        headers = [f"col_{i}" for i in range(len(rows[0]))]
+
+    if not data_rows:
+        return {"success": False, "msg": "CSV file has no data rows"}
+
+    n_cols = len(headers)
+    n_rows = len(data_rows)
+
+    # Transpose to get columns
+    columns = []
+    for col_idx in range(n_cols):
+        values = [row[col_idx] if col_idx < len(row) else "" for row in data_rows]
+        col_info = _infer_column_type(values)
+        col_info["name"] = headers[col_idx]
+        col_info["index"] = col_idx
+        columns.append(col_info)
+
+    patterns = _detect_patterns(columns)
+
+    # Data quality summary
+    total_cells = n_rows * n_cols
+    total_missing = sum(c["n_missing"] for c in columns)
+
+    return {
+        "success": True,
+        "n_rows": n_rows,
+        "n_cols": n_cols,
+        "columns": columns,
+        "patterns": patterns,
+        "data_quality": {
+            "total_missing": total_missing,
+            "pct_missing": round(100 * total_missing / total_cells, 2) if total_cells > 0 else 0,
+        },
+    }
+
+
+# Model defaults for config generation
+_SINGLE_ROUND_MODELS = {
+    "CoxProportionalHazards", "RCoxProportionalHazards",
+    "KaplanMeier", "RKaplanMeier",
+    "PoissonRegression", "RPoissonRegression",
+    "NegativeBinomialRegression", "RNegativeBinomialRegression",
+    "CensoredRegression", "RCensoredRegression",
+    "MultipleImputation", "RMultipleImputation",
+    "Ancova",
+    "LogisticRegressionStats",
+    "OrdinalLogisticRegression",
+    "MixedEffectsLogisticRegression",
+}
+
+_ITERATIVE_MODELS = {
+    "LogisticRegression", "RLogisticRegression",
+    "LinearRegression",
+    "SvmRegression",
+}
+
+_ALL_KNOWN_MODELS = _SINGLE_ROUND_MODELS | _ITERATIVE_MODELS | {"FederatedUNet"}
+
+_MODEL_EXTRA_DEFAULTS = {
+    "MultipleImputation": {"m": 5, "max_iter": 10},
+    "RMultipleImputation": {"m": 5, "max_iter": 10},
+    "MixedEffectsLogisticRegression": {"vcp_p": 1.0, "fe_p": 2.0},
+    "FederatedUNet": {
+        "local_epochs": 1,
+        "architecture": "resnet50",
+        "type_Unet": "unet",
+        "patch_size": 64,
+        "batch_size": 1,
+        "learning_rate": 0.0001,
+    },
+}
+
+
+def _execute_recommend_task(params: dict) -> dict:
+    """Recommend FL task types based on dataset analysis patterns."""
+    analysis = params.get("analysis", {})
+    preference = params.get("preference", "any")
+    patterns = analysis.get("patterns", {})
+
+    if not patterns:
+        return {
+            "success": True,
+            "recommendations": [{
+                "model": "LogisticRegression",
+                "rationale": "Default recommendation — no clear patterns detected",
+                "priority": 5,
+            }],
+        }
+
+    recommendations = []
+
+    def _add(model, rationale, priority, r_variant=None):
+        if preference == "r" and r_variant:
+            recommendations.append({"model": r_variant, "rationale": rationale, "priority": priority})
+        elif preference == "python":
+            recommendations.append({"model": model, "rationale": rationale, "priority": priority})
+        else:
+            recommendations.append({"model": model, "rationale": rationale, "priority": priority})
+            if r_variant:
+                recommendations.append({"model": r_variant, "rationale": rationale + " (R variant)", "priority": priority + 1})
+
+    if patterns.get("time_to_event"):
+        _add("CoxProportionalHazards",
+             "Time-to-event data detected (continuous time + binary event indicator)",
+             1, "RCoxProportionalHazards")
+        _add("KaplanMeier",
+             "Non-parametric survival estimation for time-to-event data",
+             2, "RKaplanMeier")
+
+    if patterns.get("missing_data"):
+        _add("MultipleImputation",
+             "Missing data detected — MICE handles incomplete observations",
+             1, "RMultipleImputation")
+
+    if patterns.get("censored"):
+        _add("CensoredRegression",
+             "Censoring indicator detected (values in {-1, 0, 1})",
+             1, "RCensoredRegression")
+
+    if patterns.get("binary_outcome") and not patterns.get("time_to_event"):
+        if patterns.get("group_column"):
+            _add("MixedEffectsLogisticRegression",
+                 "Binary outcome with group/cluster column — multilevel model appropriate",
+                 1)
+        _add("LogisticRegression",
+             "Binary outcome (0/1) detected — standard classification",
+             2, "RLogisticRegression")
+        _add("LogisticRegressionStats",
+             "Binary outcome with statistical inference (p-values, odds ratios, CI)",
+             3)
+
+    if patterns.get("ordinal_outcome") and not patterns.get("count_data"):
+        _add("OrdinalLogisticRegression",
+             "Ordinal integer outcome with 3+ levels detected",
+             2)
+
+    if patterns.get("count_data"):
+        _add("PoissonRegression",
+             "Non-negative integer outcome detected — count data model",
+             1, "RPoissonRegression")
+        _add("NegativeBinomialRegression",
+             "Alternative for overdispersed count data",
+             2, "RNegativeBinomialRegression")
+
+    if patterns.get("continuous_outcome"):
+        if patterns.get("group_column"):
+            _add("Ancova",
+                 "Continuous outcome with group column — ANCOVA for group comparisons",
+                 1)
+        _add("LinearRegression",
+             "Continuous outcome detected — standard regression",
+             2)
+
+    if not recommendations:
+        recommendations.append({
+            "model": "LogisticRegression",
+            "rationale": "Default recommendation — no specific patterns matched",
+            "priority": 5,
+        })
+
+    recommendations.sort(key=lambda r: r["priority"])
+    return {"success": True, "recommendations": recommendations}
+
+
+def _execute_generate_config(params: dict) -> dict:
+    """Generate task configuration JSON for a given model type."""
+    model = params.get("model", "")
+    if not model:
+        return {"success": False, "msg": "Model name is required"}
+    if model not in _ALL_KNOWN_MODELS:
+        return {"success": False, "msg": f"Unknown model: {model}. Known models: {sorted(_ALL_KNOWN_MODELS)}"}
+
+    # Determine default total_round
+    if model in _SINGLE_ROUND_MODELS:
+        default_rounds = 1
+    elif model == "FederatedUNet":
+        default_rounds = 5
+    else:
+        default_rounds = 5
+
+    total_round = params.get("total_round", default_rounds)
+    config = {"total_round": total_round, "current_round": 1}
+
+    # Apply model-specific defaults
+    if model in _MODEL_EXTRA_DEFAULTS:
+        config.update(_MODEL_EXTRA_DEFAULTS[model])
+
+    # Apply user overrides
+    overrides = params.get("config_overrides")
+    if overrides and isinstance(overrides, dict):
+        config.update(overrides)
+
+    tasks_json = json.dumps([{"seq": 1, "model": model, "config": config}])
+    return {"success": True, "tasks_json": tasks_json, "config": config}
+
+
+def _execute_interpret_results(params: dict) -> dict:
+    """Parse artifact files from a directory and interpret experiment results."""
+    artifact_dir = params.get("artifact_dir", "")
+    model = params.get("model", "")
+
+    if not artifact_dir or not os.path.isdir(artifact_dir):
+        return {"success": False, "msg": f"Directory not found: {artifact_dir}"}
+
+    # Walk directory for JSON files
+    results = []
+    dir_path = Path(artifact_dir)
+    json_files = sorted(dir_path.rglob("*.json")) + sorted(dir_path.rglob("*artifacts*"))
+
+    # Deduplicate
+    seen = set()
+    unique_files = []
+    for f in json_files:
+        if f.resolve() not in seen and f.is_file():
+            seen.add(f.resolve())
+            unique_files.append(f)
+
+    if not unique_files:
+        # Try reading files without extension (artifacts are often extensionless)
+        for f in sorted(dir_path.rglob("*")):
+            if f.is_file() and f.resolve() not in seen:
+                seen.add(f.resolve())
+                unique_files.append(f)
+
+    parsed_files = []
+    for fpath in unique_files:
+        try:
+            text = fpath.read_text().strip()
+            if not text:
+                continue
+            data = json.loads(text)
+            parsed_files.append({"file": str(fpath.relative_to(dir_path)), "data": data})
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+
+    if not parsed_files:
+        return {"success": False, "msg": "No parseable artifact files found in directory"}
+
+    # Extract metrics and coefficients
+    all_metrics = {}
+    all_coefficients = {}
+    all_diagnostics = {}
+
+    for pf in parsed_files:
+        data = pf["data"]
+        file_name = pf["file"]
+
+        # Collect known metric keys
+        for key, val in data.items():
+            if key.startswith("metric_") and isinstance(val, (int, float)):
+                all_metrics.setdefault(key, []).append({"file": file_name, "value": val})
+            elif key == "coef_":
+                all_coefficients[file_name] = val
+            elif key == "intercept_":
+                all_coefficients.setdefault(file_name + "_intercept", val)
+            elif key == "diagnostics" and isinstance(val, dict):
+                all_diagnostics[file_name] = val
+            elif key == "concordance_index" and isinstance(val, (int, float)):
+                all_metrics.setdefault("concordance_index", []).append({"file": file_name, "value": val})
+            elif key == "sample_size" and isinstance(val, (int, float)):
+                all_metrics.setdefault("sample_size", []).append({"file": file_name, "value": val})
+
+    # Compute metric summaries
+    metric_summary = {}
+    for metric_name, values in all_metrics.items():
+        vals = [v["value"] for v in values]
+        metric_summary[metric_name] = {
+            "mean": round(statistics.mean(vals), 4) if vals else None,
+            "values": values,
+        }
+
+    # Build key findings
+    key_findings = []
+    for metric_name, summary in metric_summary.items():
+        mean_val = summary["mean"]
+        if mean_val is None:
+            continue
+        if "acc" in metric_name and mean_val > 0.8:
+            key_findings.append(f"Good accuracy: {metric_name} = {mean_val}")
+        elif "acc" in metric_name:
+            key_findings.append(f"Moderate accuracy: {metric_name} = {mean_val}")
+        if "auc" in metric_name and mean_val > 0.8:
+            key_findings.append(f"Good discrimination: {metric_name} = {mean_val}")
+        elif "auc" in metric_name:
+            key_findings.append(f"Moderate discrimination: {metric_name} = {mean_val}")
+        if "r2" in metric_name and mean_val > 0.6:
+            key_findings.append(f"Reasonable fit: {metric_name} = {mean_val}")
+        elif "r2" in metric_name:
+            key_findings.append(f"Weak fit: {metric_name} = {mean_val}")
+        if metric_name == "concordance_index" and mean_val > 0.7:
+            key_findings.append(f"Good concordance: {mean_val}")
+        elif metric_name == "concordance_index":
+            key_findings.append(f"Moderate concordance: {mean_val}")
+
+    # Check diagnostics for concerns
+    diagnostic_concerns = []
+    for file_name, diag in all_diagnostics.items():
+        vif = diag.get("vif", {})
+        if isinstance(vif, dict):
+            high_vif = {k: v for k, v in vif.items() if isinstance(v, (int, float)) and v > 10}
+            if high_vif:
+                diagnostic_concerns.append(f"High VIF (multicollinearity) in {file_name}: {high_vif}")
+        cooks = diag.get("cooks_distance", {})
+        if isinstance(cooks, dict) and cooks.get("n_influential", 0) > 0:
+            diagnostic_concerns.append(
+                f"Influential outliers detected in {file_name}: {cooks['n_influential']} points"
+            )
+
+    return {
+        "success": True,
+        "model": model or "unknown",
+        "n_artifact_files": len(parsed_files),
+        "metrics": metric_summary,
+        "coefficients": all_coefficients,
+        "diagnostics": all_diagnostics,
+        "key_findings": key_findings,
+        "diagnostic_concerns": diagnostic_concerns,
+    }
+
+
+def _execute_compare_experiments(params: dict) -> dict:
+    """Compare results from multiple FL experiments."""
+    experiments = params.get("experiments", [])
+    if not experiments:
+        return {"success": False, "msg": "No experiments to compare"}
+    if len(experiments) == 1:
+        return {
+            "success": True,
+            "comparison": "Only one experiment provided",
+            "best_model": experiments[0].get("model", "unknown"),
+            "ranking": [{"rank": 1, "model": experiments[0].get("model", "unknown")}],
+        }
+
+    # Collect all metric names across experiments
+    all_metric_names = set()
+    for exp in experiments:
+        metrics = exp.get("metrics", {})
+        all_metric_names.update(metrics.keys())
+
+    # Build comparison table
+    comparison_table = []
+    for exp in experiments:
+        model_name = exp.get("model", "unknown")
+        metrics = exp.get("metrics", {})
+        row = {"model": model_name}
+        for metric_name in sorted(all_metric_names):
+            metric_data = metrics.get(metric_name, {})
+            row[metric_name] = metric_data.get("mean") if isinstance(metric_data, dict) else None
+        comparison_table.append(row)
+
+    # Determine primary metric for ranking
+    primary_metric = None
+    metric_priority = [
+        "metric_auc", "metric_acc", "concordance_index",
+        "metric_r2", "metric_mse", "metric_mae",
+    ]
+    for m in metric_priority:
+        if m in all_metric_names:
+            primary_metric = m
+            break
+
+    # Rank experiments
+    ranking = []
+    if primary_metric:
+        # Higher is better for auc, acc, r2, concordance; lower for mse, mae
+        reverse = primary_metric not in ("metric_mse", "metric_mae")
+        scored = []
+        for row in comparison_table:
+            val = row.get(primary_metric)
+            scored.append((row["model"], val if val is not None else float("-inf") if reverse else float("inf")))
+        scored.sort(key=lambda x: x[1], reverse=reverse)
+        ranking = [{"rank": i + 1, "model": m, primary_metric: v} for i, (m, v) in enumerate(scored)]
+        best_model = ranking[0]["model"] if ranking else "unknown"
+    else:
+        ranking = [{"rank": i + 1, "model": row["model"]} for i, row in enumerate(comparison_table)]
+        best_model = comparison_table[0]["model"] if comparison_table else "unknown"
+
+    return {
+        "success": True,
+        "comparison_table": comparison_table,
+        "primary_metric": primary_metric,
+        "best_model": best_model,
+        "ranking": ranking,
+    }
+
+
+LOCAL_TOOL_HANDLERS = {
+    "analyze_dataset": _execute_analyze_dataset,
+    "recommend_task": _execute_recommend_task,
+    "generate_config": _execute_generate_config,
+    "interpret_results": _execute_interpret_results,
+    "compare_experiments": _execute_compare_experiments,
+}
+
+ALL_TOOL_HANDLERS = {**TOOL_HANDLERS, **LOCAL_TOOL_HANDLERS}
+
+
+def get_experiment_tool_schemas() -> list[dict]:
+    """Return all tool definitions including experiment-specific local tools."""
+    return TOOL_DEFINITIONS + LOCAL_TOOL_DEFINITIONS
+
+
 def execute_tool(tool_name: str, params: dict) -> str:
     """
     Execute a tool by name with the given parameters.
 
     Returns JSON string of the result.
     """
-    handler = TOOL_HANDLERS.get(tool_name)
+    handler = ALL_TOOL_HANDLERS.get(tool_name)
     if not handler:
         return json.dumps({"success": False, "msg": f"Unknown tool: {tool_name}"})
     result = handler(params)

--- a/cli/tests/test_agent.py
+++ b/cli/tests/test_agent.py
@@ -237,6 +237,42 @@ class TestAgentLoop:
         call_kwargs = client.messages.create.call_args
         assert call_kwargs.kwargs["model"] == "claude-haiku-4-5-20251001"
 
+    def test_custom_system_prompt(self):
+        """Verify custom system prompt is passed to the API."""
+        client = MagicMock()
+        response = _make_response([_make_text_block("Hello")])
+        client.messages.create.return_value = response
+
+        custom_prompt = "You are a custom agent."
+        run_agent_loop("Hello", client=client, system_prompt=custom_prompt)
+
+        call_kwargs = client.messages.create.call_args
+        assert call_kwargs.kwargs["system"] == custom_prompt
+
+    def test_custom_tools_list(self):
+        """Verify custom tools are passed to the API."""
+        client = MagicMock()
+        response = _make_response([_make_text_block("Hello")])
+        client.messages.create.return_value = response
+
+        custom_tools = [{"name": "test_tool", "description": "Test", "input_schema": {"type": "object", "properties": {}, "required": []}}]
+        run_agent_loop("Hello", client=client, tools=custom_tools)
+
+        call_kwargs = client.messages.create.call_args
+        assert call_kwargs.kwargs["tools"] == custom_tools
+
+    def test_default_system_prompt_unchanged(self):
+        """Verify default prompt is used when system_prompt is None."""
+        client = MagicMock()
+        response = _make_response([_make_text_block("Hello")])
+        client.messages.create.return_value = response
+
+        run_agent_loop("Hello", client=client)
+
+        call_kwargs = client.messages.create.call_args
+        assert "Starfish-FL" in call_kwargs.kwargs["system"]
+        assert len(call_kwargs.kwargs["tools"]) == 15
+
 
 class TestExtractFinalResponse:
     """Test extracting the final text from conversation history."""

--- a/cli/tests/test_prompts.py
+++ b/cli/tests/test_prompts.py
@@ -2,7 +2,7 @@
 Tests for the system prompt content.
 """
 
-from starfish_cli.agent.prompts import SYSTEM_PROMPT
+from starfish_cli.agent.prompts import SYSTEM_PROMPT, EXPERIMENT_SYSTEM_PROMPT
 
 
 class TestSystemPrompt:
@@ -52,3 +52,49 @@ class TestSystemPrompt:
     def test_prompt_mentions_failure_handling(self):
         assert "failure" in SYSTEM_PROMPT.lower() or "failed" in SYSTEM_PROMPT.lower()
         assert "logs" in SYSTEM_PROMPT.lower()
+
+
+class TestExperimentSystemPrompt:
+    """Verify the experiment prompt extends the base prompt with experiment guidance."""
+
+    def test_experiment_prompt_extends_base(self):
+        assert SYSTEM_PROMPT in EXPERIMENT_SYSTEM_PROMPT
+
+    def test_experiment_prompt_is_longer(self):
+        assert len(EXPERIMENT_SYSTEM_PROMPT) > len(SYSTEM_PROMPT)
+
+    def test_experiment_prompt_has_decision_tree(self):
+        assert "Decision Tree" in EXPERIMENT_SYSTEM_PROMPT
+
+    def test_experiment_prompt_has_heuristics(self):
+        assert "Heuristics" in EXPERIMENT_SYSTEM_PROMPT
+
+    def test_experiment_prompt_mentions_analyze_dataset(self):
+        assert "analyze_dataset" in EXPERIMENT_SYSTEM_PROMPT
+
+    def test_experiment_prompt_mentions_interpret_results(self):
+        assert "interpret_results" in EXPERIMENT_SYSTEM_PROMPT
+
+    def test_experiment_prompt_mentions_compare_experiments(self):
+        assert "compare_experiments" in EXPERIMENT_SYSTEM_PROMPT
+
+    def test_experiment_prompt_has_refinement_guidance(self):
+        assert "Iterative Refinement" in EXPERIMENT_SYSTEM_PROMPT
+
+    def test_experiment_prompt_has_report_format(self):
+        assert "Report Format" in EXPERIMENT_SYSTEM_PROMPT
+
+    def test_experiment_prompt_mentions_round_guidance(self):
+        assert "Single-round models" in EXPERIMENT_SYSTEM_PROMPT
+        assert "Iterative models" in EXPERIMENT_SYSTEM_PROMPT
+
+    def test_experiment_prompt_has_interpretation_thresholds(self):
+        assert "AUC > 0.8" in EXPERIMENT_SYSTEM_PROMPT
+        assert "VIF > 10" in EXPERIMENT_SYSTEM_PROMPT
+        assert "Concordance > 0.7" in EXPERIMENT_SYSTEM_PROMPT
+
+    def test_experiment_prompt_mentions_recommend_task(self):
+        assert "recommend_task" in EXPERIMENT_SYSTEM_PROMPT
+
+    def test_experiment_prompt_mentions_generate_config(self):
+        assert "generate_config" in EXPERIMENT_SYSTEM_PROMPT

--- a/cli/tests/test_runner.py
+++ b/cli/tests/test_runner.py
@@ -1,5 +1,5 @@
 """
-Tests for the agent CLI runner (starfish agent run/tools commands).
+Tests for the agent CLI runner (starfish agent run/tools/experiment commands).
 """
 
 import json
@@ -33,6 +33,21 @@ class TestToolsCommand:
         assert result.exit_code == 0
         assert "Starfish Agent Tools" in result.output
         assert "starfish_site_info" in result.output
+
+    def test_tools_all_json_output(self):
+        result = runner.invoke(app, ["tools", "--json", "--all"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 20
+        names = {t["name"] for t in data}
+        assert "analyze_dataset" in names
+        assert "recommend_task" in names
+
+    def test_tools_all_table_output(self):
+        result = runner.invoke(app, ["tools", "--all"])
+        assert result.exit_code == 0
+        assert "all" in result.output.lower()
+        assert "analyze_dataset" in result.output
 
 
 class TestRunCommand:
@@ -112,5 +127,107 @@ class TestRunCommand:
         mock_extract.return_value = ""
 
         result = runner.invoke(app, ["run", "test", "--api-key", "key"])
+        assert result.exit_code == 0
+        assert "completed without a final text response" in result.output
+
+
+class TestExperimentCommand:
+    """Test `starfish agent experiment` command."""
+
+    def test_experiment_without_api_key_fails(self):
+        with patch.dict("os.environ", {}, clear=True):
+            result = runner.invoke(app, ["experiment", "test experiment"])
+            assert result.exit_code == 1
+
+    @patch(f"{_AGENT_MOD}.run_agent_loop")
+    @patch(f"{_AGENT_MOD}.extract_final_response")
+    def test_experiment_with_api_key(self, mock_extract, mock_loop):
+        mock_loop.return_value = []
+        mock_extract.return_value = "Experiment completed."
+
+        result = runner.invoke(app, [
+            "experiment", "analyze data.csv and run FL", "--api-key", "test-key"
+        ])
+        assert result.exit_code == 0
+        assert "Experiment completed." in result.output
+        mock_loop.assert_called_once()
+
+    @patch(f"{_AGENT_MOD}.run_agent_loop")
+    @patch(f"{_AGENT_MOD}.extract_final_response")
+    def test_experiment_default_max_turns(self, mock_extract, mock_loop):
+        mock_loop.return_value = []
+        mock_extract.return_value = "Done."
+
+        runner.invoke(app, [
+            "experiment", "test", "--api-key", "key"
+        ])
+
+        call_kwargs = mock_loop.call_args
+        assert call_kwargs.kwargs["max_turns"] == 100
+
+    @patch(f"{_AGENT_MOD}.run_agent_loop")
+    @patch(f"{_AGENT_MOD}.extract_final_response")
+    def test_experiment_uses_experiment_prompt(self, mock_extract, mock_loop):
+        mock_loop.return_value = []
+        mock_extract.return_value = "Done."
+
+        runner.invoke(app, [
+            "experiment", "test", "--api-key", "key"
+        ])
+
+        call_kwargs = mock_loop.call_args
+        system_prompt = call_kwargs.kwargs["system_prompt"]
+        assert "Autonomous Experiment Mode" in system_prompt
+
+    @patch(f"{_AGENT_MOD}.run_agent_loop")
+    @patch(f"{_AGENT_MOD}.extract_final_response")
+    def test_experiment_uses_all_tools(self, mock_extract, mock_loop):
+        mock_loop.return_value = []
+        mock_extract.return_value = "Done."
+
+        runner.invoke(app, [
+            "experiment", "test", "--api-key", "key"
+        ])
+
+        call_kwargs = mock_loop.call_args
+        tools = call_kwargs.kwargs["tools"]
+        assert len(tools) == 20
+        tool_names = {t["name"] for t in tools}
+        assert "analyze_dataset" in tool_names
+        assert "starfish_site_info" in tool_names
+
+    @patch(f"{_AGENT_MOD}.run_agent_loop")
+    @patch(f"{_AGENT_MOD}.extract_final_response")
+    def test_experiment_verbose(self, mock_extract, mock_loop):
+        mock_loop.return_value = []
+        mock_extract.return_value = "Done."
+
+        result = runner.invoke(app, [
+            "experiment", "test", "--api-key", "key", "--verbose"
+        ])
+        assert result.exit_code == 0
+        assert "Experiment goal: test" in result.output
+        assert "autonomous experiment" in result.output
+
+    @patch(f"{_AGENT_MOD}.run_agent_loop")
+    def test_experiment_json_output(self, mock_loop):
+        mock_loop.return_value = [
+            {"role": "user", "content": "test"},
+        ]
+
+        result = runner.invoke(app, [
+            "experiment", "test", "--api-key", "key", "--json"
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+
+    @patch(f"{_AGENT_MOD}.run_agent_loop")
+    @patch(f"{_AGENT_MOD}.extract_final_response")
+    def test_experiment_empty_response(self, mock_extract, mock_loop):
+        mock_loop.return_value = []
+        mock_extract.return_value = ""
+
+        result = runner.invoke(app, ["experiment", "test", "--api-key", "key"])
         assert result.exit_code == 0
         assert "completed without a final text response" in result.output

--- a/cli/tests/test_tools.py
+++ b/cli/tests/test_tools.py
@@ -2,17 +2,28 @@
 Tests for agent tool definitions and execution.
 """
 
+import csv
 import json
+import os
 import pytest
 from unittest.mock import patch, MagicMock
 
 from starfish_cli.agent.tools import (
     get_tool_schemas,
+    get_experiment_tool_schemas,
     execute_tool,
     TOOL_HANDLERS,
     TOOL_DEFINITIONS,
+    LOCAL_TOOL_DEFINITIONS,
+    LOCAL_TOOL_HANDLERS,
+    ALL_TOOL_HANDLERS,
     _run_cli,
     _build_cmd,
+    _infer_column_type,
+    _detect_patterns,
+    _ALL_KNOWN_MODELS,
+    _SINGLE_ROUND_MODELS,
+    _ITERATIVE_MODELS,
 )
 
 
@@ -136,6 +147,54 @@ class TestToolSchemas:
         }
 
 
+class TestExperimentToolSchemas:
+    """Test experiment-specific tool schemas."""
+
+    def test_experiment_tool_count(self):
+        assert len(get_experiment_tool_schemas()) == 20
+
+    def test_experiment_tools_include_cli_tools(self):
+        exp_names = {t["name"] for t in get_experiment_tool_schemas()}
+        cli_names = {t["name"] for t in get_tool_schemas()}
+        assert cli_names.issubset(exp_names)
+
+    def test_expected_experiment_tools_exist(self):
+        names = {t["name"] for t in get_experiment_tool_schemas()}
+        expected_local = {
+            "analyze_dataset",
+            "recommend_task",
+            "generate_config",
+            "interpret_results",
+            "compare_experiments",
+        }
+        assert expected_local.issubset(names)
+
+    def test_all_experiment_tools_have_required_fields(self):
+        for tool in get_experiment_tool_schemas():
+            assert "name" in tool
+            assert "description" in tool
+            assert "input_schema" in tool
+            schema = tool["input_schema"]
+            assert schema["type"] == "object"
+            assert "properties" in schema
+            assert "required" in schema
+
+    def test_all_experiment_tool_names_are_unique(self):
+        names = [t["name"] for t in get_experiment_tool_schemas()]
+        assert len(names) == len(set(names))
+
+    def test_every_experiment_tool_has_handler(self):
+        for tool in get_experiment_tool_schemas():
+            assert tool["name"] in ALL_TOOL_HANDLERS, (
+                f"Tool {tool['name']} has no handler"
+            )
+
+    def test_local_tool_handlers_match_definitions(self):
+        local_names = {t["name"] for t in LOCAL_TOOL_DEFINITIONS}
+        handler_names = set(LOCAL_TOOL_HANDLERS.keys())
+        assert local_names == handler_names
+
+
 class TestBuildCmd:
     """Test CLI command construction."""
 
@@ -227,8 +286,6 @@ class TestRunCli:
         )
         _run_cli(["site", "info"])
         call_kwargs = mock_run.call_args
-        # STARFISH_ENV should not be explicitly set
-        env = call_kwargs.kwargs["env"]
         # It inherits from os.environ but we didn't set it explicitly
         # Just verify the call succeeded
 
@@ -426,3 +483,530 @@ class TestExecuteTool:
             parsed = json.loads(result)
             assert parsed["success"] is True
             assert parsed["data"]["id"] == 1
+
+    def test_execute_tool_dispatches_local_tools(self):
+        """Verify execute_tool can dispatch to local experiment tools."""
+        # generate_config is a local tool that doesn't need filesystem
+        result = json.loads(execute_tool("generate_config", {"model": "LogisticRegression"}))
+        assert result["success"] is True
+        assert "tasks_json" in result
+
+
+# ---------------------------------------------------------------------------
+# Tests for local experiment tools
+# ---------------------------------------------------------------------------
+
+def _write_csv(path, rows, header=None):
+    """Helper to write a CSV file for testing."""
+    with open(path, "w", newline="") as f:
+        writer = csv.writer(f)
+        if header:
+            writer.writerow(header)
+        writer.writerows(rows)
+
+
+class TestAnalyzeDataset:
+    """Test the analyze_dataset local tool."""
+
+    def test_analyze_csv_basic(self, tmp_path):
+        csv_path = tmp_path / "data.csv"
+        _write_csv(csv_path, [
+            ["1.0", "2.0", "0"],
+            ["3.0", "4.0", "1"],
+            ["5.0", "6.0", "0"],
+        ])
+        result = json.loads(execute_tool("analyze_dataset", {"file_path": str(csv_path)}))
+        assert result["success"] is True
+        assert result["n_rows"] == 3
+        assert result["n_cols"] == 3
+        assert len(result["columns"]) == 3
+
+    def test_analyze_detects_binary_outcome(self, tmp_path):
+        csv_path = tmp_path / "binary.csv"
+        _write_csv(csv_path, [
+            ["1.5", "2.3", "0"],
+            ["3.1", "4.7", "1"],
+            ["5.2", "6.1", "0"],
+            ["7.0", "8.0", "1"],
+        ])
+        result = json.loads(execute_tool("analyze_dataset", {"file_path": str(csv_path)}))
+        assert result["success"] is True
+        assert result["patterns"].get("binary_outcome") is True
+
+    def test_analyze_detects_continuous_outcome(self, tmp_path):
+        csv_path = tmp_path / "continuous.csv"
+        _write_csv(csv_path, [
+            ["1.0", "2.0", "3.14"],
+            ["4.0", "5.0", "6.28"],
+            ["7.0", "8.0", "9.42"],
+        ])
+        result = json.loads(execute_tool("analyze_dataset", {"file_path": str(csv_path)}))
+        assert result["success"] is True
+        assert result["patterns"].get("continuous_outcome") is True
+
+    def test_analyze_detects_time_to_event(self, tmp_path):
+        csv_path = tmp_path / "survival.csv"
+        _write_csv(csv_path, [
+            ["1.0", "2.0", "10.5", "1"],
+            ["3.0", "4.0", "20.3", "0"],
+            ["5.0", "6.0", "15.1", "1"],
+            ["7.0", "8.0", "30.0", "0"],
+        ])
+        result = json.loads(execute_tool("analyze_dataset", {"file_path": str(csv_path)}))
+        assert result["success"] is True
+        assert result["patterns"].get("time_to_event") is True
+
+    def test_analyze_detects_count_data(self, tmp_path):
+        csv_path = tmp_path / "count.csv"
+        _write_csv(csv_path, [
+            ["1.0", "2.5", "0"],
+            ["3.0", "4.5", "3"],
+            ["5.0", "6.5", "7"],
+            ["7.0", "8.5", "2"],
+        ])
+        result = json.loads(execute_tool("analyze_dataset", {"file_path": str(csv_path)}))
+        assert result["success"] is True
+        assert result["patterns"].get("count_data") is True
+
+    def test_analyze_detects_censoring_indicator(self, tmp_path):
+        csv_path = tmp_path / "censored.csv"
+        _write_csv(csv_path, [
+            ["1.0", "10.5", "0"],
+            ["3.0", "20.3", "1"],
+            ["5.0", "15.1", "-1"],
+            ["7.0", "30.0", "0"],
+        ])
+        result = json.loads(execute_tool("analyze_dataset", {"file_path": str(csv_path)}))
+        assert result["success"] is True
+        assert result["patterns"].get("censored") is True
+
+    def test_analyze_detects_missing_data(self, tmp_path):
+        csv_path = tmp_path / "missing.csv"
+        _write_csv(csv_path, [
+            ["1.0", "", "0"],
+            ["3.0", "4.0", "1"],
+            ["", "6.0", "0"],
+        ])
+        result = json.loads(execute_tool("analyze_dataset", {"file_path": str(csv_path)}))
+        assert result["success"] is True
+        assert result["patterns"].get("missing_data") is True
+        assert result["data_quality"]["total_missing"] == 2
+
+    def test_analyze_detects_ordinal_outcome(self, tmp_path):
+        csv_path = tmp_path / "ordinal.csv"
+        _write_csv(csv_path, [
+            ["1.0", "2.0", "0"],
+            ["3.0", "4.0", "1"],
+            ["5.0", "6.0", "2"],
+            ["7.0", "8.0", "3"],
+        ])
+        result = json.loads(execute_tool("analyze_dataset", {"file_path": str(csv_path)}))
+        assert result["success"] is True
+        assert result["patterns"].get("ordinal_outcome") is True
+
+    def test_analyze_file_not_found(self):
+        result = json.loads(execute_tool("analyze_dataset", {"file_path": "/no/such/file.csv"}))
+        assert result["success"] is False
+        assert "not found" in result["msg"].lower() or "File not found" in result["msg"]
+
+    def test_analyze_empty_file(self, tmp_path):
+        csv_path = tmp_path / "empty.csv"
+        csv_path.write_text("")
+        result = json.loads(execute_tool("analyze_dataset", {"file_path": str(csv_path)}))
+        assert result["success"] is False
+
+    def test_analyze_with_header(self, tmp_path):
+        csv_path = tmp_path / "header.csv"
+        _write_csv(csv_path, [
+            ["1.0", "2.0", "0"],
+            ["3.0", "4.0", "1"],
+        ], header=["age", "weight", "outcome"])
+        result = json.loads(execute_tool("analyze_dataset", {
+            "file_path": str(csv_path), "has_header": True
+        }))
+        assert result["success"] is True
+        assert result["n_rows"] == 2
+        assert result["columns"][0]["name"] == "age"
+
+    def test_analyze_column_type_inference(self, tmp_path):
+        csv_path = tmp_path / "types.csv"
+        _write_csv(csv_path, [
+            ["hello", "1.5", "0"],
+            ["world", "2.5", "1"],
+            ["foo", "3.5", "0"],
+        ])
+        result = json.loads(execute_tool("analyze_dataset", {"file_path": str(csv_path)}))
+        assert result["success"] is True
+        assert result["columns"][0]["dtype"] == "categorical"
+        assert result["columns"][1]["dtype"] == "numeric_continuous"
+        assert result["columns"][2]["dtype"] == "binary"
+
+
+class TestRecommendTask:
+    """Test the recommend_task local tool."""
+
+    def test_recommend_binary_classification(self):
+        analysis = {"patterns": {"binary_outcome": True}}
+        result = json.loads(execute_tool("recommend_task", {"analysis": analysis}))
+        assert result["success"] is True
+        models = [r["model"] for r in result["recommendations"]]
+        assert "LogisticRegression" in models
+
+    def test_recommend_survival(self):
+        analysis = {"patterns": {"binary_outcome": True, "time_to_event": True}}
+        result = json.loads(execute_tool("recommend_task", {"analysis": analysis}))
+        models = [r["model"] for r in result["recommendations"]]
+        assert "CoxProportionalHazards" in models
+        assert "KaplanMeier" in models
+
+    def test_recommend_count_data(self):
+        analysis = {"patterns": {"count_data": True}}
+        result = json.loads(execute_tool("recommend_task", {"analysis": analysis}))
+        models = [r["model"] for r in result["recommendations"]]
+        assert "PoissonRegression" in models
+        assert "NegativeBinomialRegression" in models
+
+    def test_recommend_censored(self):
+        analysis = {"patterns": {"censored": True}}
+        result = json.loads(execute_tool("recommend_task", {"analysis": analysis}))
+        models = [r["model"] for r in result["recommendations"]]
+        assert "CensoredRegression" in models
+
+    def test_recommend_continuous(self):
+        analysis = {"patterns": {"continuous_outcome": True}}
+        result = json.loads(execute_tool("recommend_task", {"analysis": analysis}))
+        models = [r["model"] for r in result["recommendations"]]
+        assert "LinearRegression" in models
+
+    def test_recommend_missing_data(self):
+        analysis = {"patterns": {"missing_data": True}}
+        result = json.loads(execute_tool("recommend_task", {"analysis": analysis}))
+        models = [r["model"] for r in result["recommendations"]]
+        assert "MultipleImputation" in models
+
+    def test_recommend_ordinal(self):
+        analysis = {"patterns": {"ordinal_outcome": True}}
+        result = json.loads(execute_tool("recommend_task", {"analysis": analysis}))
+        models = [r["model"] for r in result["recommendations"]]
+        assert "OrdinalLogisticRegression" in models
+
+    def test_recommend_mixed_effects(self):
+        analysis = {"patterns": {"binary_outcome": True, "group_column": True}}
+        result = json.loads(execute_tool("recommend_task", {"analysis": analysis}))
+        models = [r["model"] for r in result["recommendations"]]
+        assert "MixedEffectsLogisticRegression" in models
+
+    def test_recommend_filters_by_python_preference(self):
+        analysis = {"patterns": {"binary_outcome": True, "time_to_event": True}}
+        result = json.loads(execute_tool("recommend_task", {
+            "analysis": analysis, "preference": "python"
+        }))
+        models = [r["model"] for r in result["recommendations"]]
+        assert "CoxProportionalHazards" in models
+        assert "RCoxProportionalHazards" not in models
+
+    def test_recommend_filters_by_r_preference(self):
+        analysis = {"patterns": {"binary_outcome": True, "time_to_event": True}}
+        result = json.loads(execute_tool("recommend_task", {
+            "analysis": analysis, "preference": "r"
+        }))
+        models = [r["model"] for r in result["recommendations"]]
+        assert "RCoxProportionalHazards" in models
+        assert "CoxProportionalHazards" not in models
+
+    def test_recommend_no_patterns_gives_default(self):
+        result = json.loads(execute_tool("recommend_task", {"analysis": {"patterns": {}}}))
+        assert result["success"] is True
+        assert len(result["recommendations"]) >= 1
+
+    def test_recommend_sorted_by_priority(self):
+        analysis = {"patterns": {"binary_outcome": True}}
+        result = json.loads(execute_tool("recommend_task", {"analysis": analysis}))
+        priorities = [r["priority"] for r in result["recommendations"]]
+        assert priorities == sorted(priorities)
+
+
+class TestGenerateConfig:
+    """Test the generate_config local tool."""
+
+    def test_generate_logistic_regression_default(self):
+        result = json.loads(execute_tool("generate_config", {"model": "LogisticRegression"}))
+        assert result["success"] is True
+        tasks = json.loads(result["tasks_json"])
+        assert len(tasks) == 1
+        assert tasks[0]["model"] == "LogisticRegression"
+        assert tasks[0]["config"]["total_round"] == 5
+        assert tasks[0]["config"]["current_round"] == 1
+        assert tasks[0]["seq"] == 1
+
+    def test_generate_single_round_model(self):
+        result = json.loads(execute_tool("generate_config", {"model": "CoxProportionalHazards"}))
+        tasks = json.loads(result["tasks_json"])
+        assert tasks[0]["config"]["total_round"] == 1
+
+    def test_generate_custom_total_round(self):
+        result = json.loads(execute_tool("generate_config", {
+            "model": "LogisticRegression", "total_round": 10
+        }))
+        tasks = json.loads(result["tasks_json"])
+        assert tasks[0]["config"]["total_round"] == 10
+
+    def test_generate_with_config_overrides(self):
+        result = json.loads(execute_tool("generate_config", {
+            "model": "MultipleImputation",
+            "config_overrides": {"m": 10, "max_iter": 20}
+        }))
+        tasks = json.loads(result["tasks_json"])
+        assert tasks[0]["config"]["m"] == 10
+        assert tasks[0]["config"]["max_iter"] == 20
+
+    def test_generate_unknown_model(self):
+        result = json.loads(execute_tool("generate_config", {"model": "FakeModel"}))
+        assert result["success"] is False
+        assert "Unknown model" in result["msg"]
+
+    def test_generate_r_variant(self):
+        result = json.loads(execute_tool("generate_config", {"model": "RLogisticRegression"}))
+        assert result["success"] is True
+        tasks = json.loads(result["tasks_json"])
+        assert tasks[0]["model"] == "RLogisticRegression"
+
+    def test_generate_unet_config(self):
+        result = json.loads(execute_tool("generate_config", {"model": "FederatedUNet"}))
+        tasks = json.loads(result["tasks_json"])
+        assert tasks[0]["config"]["architecture"] == "resnet50"
+        assert tasks[0]["config"]["patch_size"] == 64
+
+    def test_generated_config_is_valid_json(self):
+        for model in ["LogisticRegression", "CoxProportionalHazards", "MultipleImputation"]:
+            result = json.loads(execute_tool("generate_config", {"model": model}))
+            tasks = json.loads(result["tasks_json"])
+            assert isinstance(tasks, list)
+            assert len(tasks) == 1
+            assert "seq" in tasks[0]
+            assert "model" in tasks[0]
+            assert "config" in tasks[0]
+
+    def test_generate_empty_model(self):
+        result = json.loads(execute_tool("generate_config", {"model": ""}))
+        assert result["success"] is False
+
+    def test_model_sets_known(self):
+        """Verify model categorization is consistent."""
+        assert "LogisticRegression" in _ITERATIVE_MODELS
+        assert "CoxProportionalHazards" in _SINGLE_ROUND_MODELS
+        assert "FederatedUNet" in _ALL_KNOWN_MODELS
+        assert _ALL_KNOWN_MODELS == _SINGLE_ROUND_MODELS | _ITERATIVE_MODELS | {"FederatedUNet"}
+
+
+class TestInterpretResults:
+    """Test the interpret_results local tool."""
+
+    def test_interpret_classification_artifacts(self, tmp_path):
+        artifact = {
+            "coef_": [[0.5, -0.3]],
+            "intercept_": [0.1],
+            "metric_acc": 0.85,
+            "metric_auc": 0.91,
+            "sample_size": 100,
+        }
+        (tmp_path / "site1.json").write_text(json.dumps(artifact))
+        result = json.loads(execute_tool("interpret_results", {
+            "artifact_dir": str(tmp_path), "model": "LogisticRegression"
+        }))
+        assert result["success"] is True
+        assert result["model"] == "LogisticRegression"
+        assert "metric_acc" in result["metrics"]
+        assert "metric_auc" in result["metrics"]
+
+    def test_interpret_regression_artifacts(self, tmp_path):
+        artifact = {
+            "coef_": [[1.2, -0.8]],
+            "intercept_": [3.0],
+            "metric_r2": 0.72,
+            "metric_mse": 0.15,
+            "sample_size": 200,
+        }
+        (tmp_path / "site1.json").write_text(json.dumps(artifact))
+        result = json.loads(execute_tool("interpret_results", {
+            "artifact_dir": str(tmp_path), "model": "LinearRegression"
+        }))
+        assert result["success"] is True
+        assert "metric_r2" in result["metrics"]
+
+    def test_interpret_survival_artifacts(self, tmp_path):
+        artifact = {
+            "coef_": [[0.3, -0.5]],
+            "concordance_index": 0.78,
+            "sample_size": 150,
+        }
+        (tmp_path / "site1.json").write_text(json.dumps(artifact))
+        result = json.loads(execute_tool("interpret_results", {
+            "artifact_dir": str(tmp_path), "model": "CoxProportionalHazards"
+        }))
+        assert result["success"] is True
+        assert "concordance_index" in result["metrics"]
+
+    def test_interpret_multiple_sites(self, tmp_path):
+        for i, acc in enumerate([0.80, 0.85, 0.90]):
+            artifact = {"metric_acc": acc, "sample_size": 100}
+            (tmp_path / f"site{i}.json").write_text(json.dumps(artifact))
+        result = json.loads(execute_tool("interpret_results", {
+            "artifact_dir": str(tmp_path)
+        }))
+        assert result["success"] is True
+        assert result["n_artifact_files"] == 3
+        assert len(result["metrics"]["metric_acc"]["values"]) == 3
+
+    def test_interpret_empty_directory(self, tmp_path):
+        result = json.loads(execute_tool("interpret_results", {
+            "artifact_dir": str(tmp_path)
+        }))
+        assert result["success"] is False
+
+    def test_interpret_invalid_json(self, tmp_path):
+        (tmp_path / "bad.json").write_text("not json{{{")
+        result = json.loads(execute_tool("interpret_results", {
+            "artifact_dir": str(tmp_path)
+        }))
+        assert result["success"] is False
+
+    def test_interpret_with_diagnostics(self, tmp_path):
+        artifact = {
+            "metric_acc": 0.85,
+            "diagnostics": {
+                "vif": {"age": 15.0, "weight": 2.0},
+                "cooks_distance": {"n_influential": 3, "max": 0.5},
+            },
+        }
+        (tmp_path / "site1.json").write_text(json.dumps(artifact))
+        result = json.loads(execute_tool("interpret_results", {
+            "artifact_dir": str(tmp_path)
+        }))
+        assert result["success"] is True
+        assert len(result["diagnostic_concerns"]) > 0
+        assert any("VIF" in c for c in result["diagnostic_concerns"])
+
+    def test_interpret_directory_not_found(self):
+        result = json.loads(execute_tool("interpret_results", {
+            "artifact_dir": "/no/such/directory"
+        }))
+        assert result["success"] is False
+
+    def test_interpret_key_findings_good_auc(self, tmp_path):
+        artifact = {"metric_auc": 0.92}
+        (tmp_path / "site1.json").write_text(json.dumps(artifact))
+        result = json.loads(execute_tool("interpret_results", {
+            "artifact_dir": str(tmp_path)
+        }))
+        assert any("Good discrimination" in f for f in result["key_findings"])
+
+
+class TestCompareExperiments:
+    """Test the compare_experiments local tool."""
+
+    def test_compare_two_classification_models(self):
+        experiments = [
+            {"model": "LogisticRegression", "metrics": {
+                "metric_acc": {"mean": 0.85}, "metric_auc": {"mean": 0.90}
+            }},
+            {"model": "SvmRegression", "metrics": {
+                "metric_acc": {"mean": 0.80}, "metric_auc": {"mean": 0.85}
+            }},
+        ]
+        result = json.loads(execute_tool("compare_experiments", {"experiments": experiments}))
+        assert result["success"] is True
+        assert result["best_model"] == "LogisticRegression"
+        assert result["primary_metric"] == "metric_auc"
+
+    def test_compare_different_model_types(self):
+        experiments = [
+            {"model": "LogisticRegression", "metrics": {"metric_acc": {"mean": 0.85}}},
+            {"model": "CoxProportionalHazards", "metrics": {"concordance_index": {"mean": 0.75}}},
+        ]
+        result = json.loads(execute_tool("compare_experiments", {"experiments": experiments}))
+        assert result["success"] is True
+        assert len(result["comparison_table"]) == 2
+
+    def test_compare_single_experiment(self):
+        experiments = [{"model": "LogisticRegression", "metrics": {"metric_acc": {"mean": 0.85}}}]
+        result = json.loads(execute_tool("compare_experiments", {"experiments": experiments}))
+        assert result["success"] is True
+        assert result["best_model"] == "LogisticRegression"
+
+    def test_compare_empty_list(self):
+        result = json.loads(execute_tool("compare_experiments", {"experiments": []}))
+        assert result["success"] is False
+
+    def test_compare_identifies_best_by_lower_mse(self):
+        experiments = [
+            {"model": "LinearRegression", "metrics": {"metric_mse": {"mean": 0.5}}},
+            {"model": "SvmRegression", "metrics": {"metric_mse": {"mean": 0.3}}},
+        ]
+        result = json.loads(execute_tool("compare_experiments", {"experiments": experiments}))
+        assert result["success"] is True
+        # Lower MSE is better
+        assert result["best_model"] == "SvmRegression"
+
+    def test_compare_ranking_order(self):
+        experiments = [
+            {"model": "A", "metrics": {"metric_auc": {"mean": 0.70}}},
+            {"model": "B", "metrics": {"metric_auc": {"mean": 0.90}}},
+            {"model": "C", "metrics": {"metric_auc": {"mean": 0.80}}},
+        ]
+        result = json.loads(execute_tool("compare_experiments", {"experiments": experiments}))
+        ranks = [r["model"] for r in result["ranking"]]
+        assert ranks == ["B", "C", "A"]
+
+
+class TestInferColumnType:
+    """Test the column type inference helper."""
+
+    def test_binary_column(self):
+        result = _infer_column_type(["0", "1", "0", "1"])
+        assert result["dtype"] == "binary"
+
+    def test_continuous_column(self):
+        result = _infer_column_type(["1.5", "2.7", "3.14", "4.0"])
+        assert result["dtype"] == "numeric_continuous"
+
+    def test_integer_column(self):
+        result = _infer_column_type(["0", "3", "7", "2"])
+        assert result["dtype"] == "numeric_integer"
+
+    def test_categorical_column(self):
+        result = _infer_column_type(["cat", "dog", "cat", "bird"])
+        assert result["dtype"] == "categorical"
+
+    def test_empty_values(self):
+        result = _infer_column_type(["", "", ""])
+        assert result["dtype"] == "empty"
+
+    def test_missing_count(self):
+        result = _infer_column_type(["1.0", "", "3.0", ""])
+        assert result["n_missing"] == 2
+
+
+class TestDetectPatterns:
+    """Test the pattern detection helper."""
+
+    def test_empty_columns(self):
+        assert _detect_patterns([]) == {}
+
+    def test_binary_outcome_pattern(self):
+        columns = [
+            {"dtype": "numeric_continuous", "n_unique": 10, "n_missing": 0, "stats": {}},
+            {"dtype": "binary", "n_unique": 2, "n_missing": 0, "stats": {"min": 0, "max": 1}},
+        ]
+        patterns = _detect_patterns(columns)
+        assert patterns.get("binary_outcome") is True
+
+    def test_continuous_outcome_with_group(self):
+        columns = [
+            {"dtype": "numeric_integer", "n_unique": 3, "n_missing": 0, "stats": {}},
+            {"dtype": "numeric_continuous", "n_unique": 50, "n_missing": 0, "stats": {}},
+            {"dtype": "numeric_continuous", "n_unique": 100, "n_missing": 0, "stats": {}},
+        ]
+        patterns = _detect_patterns(columns)
+        assert patterns.get("continuous_outcome") is True
+        assert patterns.get("group_column") is True


### PR DESCRIPTION
## Summary

- Adds 5 new **local experiment tools** to the CLI agent: `analyze_dataset`, `recommend_task`, `generate_config`, `interpret_results`, `compare_experiments`
- Adds new `starfish agent experiment` CLI command for fully autonomous FL experiments (analyze data, select model, run, interpret, iterate)
- Extends `run_agent_loop()` with optional `system_prompt` and `tools` parameters (backward compatible)
- Adds `EXPERIMENT_SYSTEM_PROMPT` with dataset analysis heuristics, task selection decision tree, result interpretation guidelines, and iterative refinement guidance
- Updates `starfish agent tools --all` to list all 20 tools (15 CLI + 5 experiment)
- 173 tests pass (all existing + ~70 new), no new dependencies (stdlib only)

Closes #54

## Test plan

- [x] All 173 CLI agent tests pass (`poetry run pytest tests/ -v`)
- [ ] CI: cli-agent-tests workflow passes on Python 3.10
- [ ] Verify `starfish agent tools --all` lists 20 tools
- [ ] Verify `starfish agent experiment "..." --api-key <key>` runs with experiment prompt and all tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)