### PR TITLE
Update citation to AcT stroke trial preprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,11 +331,13 @@ For issues, questions, or contributions:
 
 If you use Starfish in your research, please cite:
 
-```
-@software{starfish,
-  title = {Starfish-FL: A Federated Learning System},
-  author = {DENOS Lab},
+```bibtex
+@article{bao2026starfish,
+  title = {Privacy-Preserving Federated Analysis Reproduces Non-Inferiority Results from the {AcT} Multicentre Stroke Trial},
+  author = {Bao, Yunkai and Saad, Zainab and Duarte, Kaue and Abbas, Farhan and Sajobi, Tolulope and Holodinsky, Jessalyn K. and Menon, Bijoy K. and Drew, Steve},
+  journal = {SSRN preprint},
   year = {2026},
-  url = {https://github.com/denoslab/starfish-fl}
+  doi = {10.2139/ssrn.6426303},
+  url = {https://ssrn.com/abstract=6426303}
 }
 ```


### PR DESCRIPTION
## Summary
- Replace placeholder software citation with the published SSRN preprint: Bao et al., "Privacy-Preserving Federated Analysis Reproduces Non-Inferiority Results from the AcT Multicentre Stroke Trial" (DOI: 10.2139/ssrn.6426303)

## Test plan
- [x] Verify BibTeX entry renders correctly in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)